### PR TITLE
feat: add concept of "main" site per account

### DIFF
--- a/api/doc/sites/patch-req-body/schema.js
+++ b/api/doc/sites/patch-req-body/schema.js
@@ -3,7 +3,7 @@ import SiteSchema from '#types/site/schema.js'
 
 const schema = jsonSchema(SiteSchema)
   .removeReadonlyProperties()
-  .pickProperties(['title', 'theme', 'reducedPersonalInfoAtCreation', 'tosMessage', 'mails', 'authMode', 'authOnlyOtherSite', 'authProviders'])
+  .pickProperties(['title', 'isAccountMain', 'theme', 'reducedPersonalInfoAtCreation', 'tosMessage', 'mails', 'authMode', 'authOnlyOtherSite', 'authProviders'])
   .appendTitle(' patch')
   .schema
 
@@ -27,7 +27,7 @@ schema.layout = {
         pt: 'Informações gerais',
         es: 'Información general'
       },
-      children: ['title']
+      children: ['title', 'isAccountMain']
     },
     { key: 'theme' },
     { key: 'mails' },

--- a/api/src/sites/router.ts
+++ b/api/src/sites/router.ts
@@ -3,7 +3,7 @@ import { Router, type Request } from 'express'
 import config from '#config'
 import { reqUser, reqUserAuthenticated, reqSiteUrl, httpError, reqSessionAuthenticated, reqHost, reqSitePath, type AccountKeys } from '@data-fair/lib-express'
 import { nanoid } from 'nanoid'
-import { findAllSites, findOwnerSites, patchSite, deleteSite, getSite } from './service.ts'
+import { findAllSites, findOwnerSites, patchSite, deleteSite, getSite, toggleMainSite } from './service.ts'
 import { isOIDCProvider, reqSite } from '#services'
 import { reqI18n } from '#i18n'
 import { getOidcProviderId } from '../oauth/oidc.ts'
@@ -175,6 +175,12 @@ router.patch('/:id', async (req, res, next) => {
   }
 
   const patchedSite = await patchSite({ _id: req.params.id, ...patch })
+
+  if (patch.isAccountMain) {
+    // toggle the main site
+    await toggleMainSite(patchedSite)
+  }
+
   res.send(patchedSite)
 })
 

--- a/api/src/sites/router.ts
+++ b/api/src/sites/router.ts
@@ -196,6 +196,7 @@ router.get('/_public', async (req, res, next) => {
       main: true,
       host: reqHost(req),
       theme,
+      isAccountMain: true,
       authMode: 'onlyLocal',
     }
     res.send(sitePublic)
@@ -204,6 +205,7 @@ router.get('/_public', async (req, res, next) => {
       host: site.host,
       path: site.path,
       title: site.title,
+      isAccountMain: site.isAccountMain,
       theme: {
         ...theme,
         logo: site.theme.logo || `${reqSiteUrl(req) + '/simple-directory'}/api/avatars/${site.owner.type}/${site.owner.id}/avatar.png`

--- a/api/types/site-public/schema.json
+++ b/api/types/site-public/schema.json
@@ -22,6 +22,9 @@
     "title": {
       "$ref": "https://github.com/data-fair/simple-directory/site#/properties/title"
     },
+    "isAccountMain": {
+      "$ref": "https://github.com/data-fair/simple-directory/site#/properties/isAccountMain"
+    },
     "theme": {
       "$ref": "https://github.com/data-fair/lib/theme"
     },

--- a/api/types/site/schema.js
+++ b/api/types/site/schema.js
@@ -93,17 +93,33 @@ export default {
         de: 'Website-Titel'
       }
     },
+    isAccountMain: {
+      type: 'boolean',
+      title: 'Site principal du compte',
+      'x-i18n-title': {
+        fr: 'Site principal du compte',
+        en: 'Main site of the account',
+        de: 'Hauptwebsite des Kontos',
+        it: 'Sito principale dell\'account',
+        pt: 'Site principal da conta',
+        es: 'Sitio principal de la cuenta'
+      }
+    },
     theme: { $ref: 'https://github.com/data-fair/lib/theme' },
     authMode: {
+      deprecated: true,
+      layout: {
+        if: '!context.otherSites.some(s => s.isAccountMain) && !parent.data.isAccountMain'
+      },
       default: 'onlyBackOffice',
-      title: "Mode d'authentification",
+      title: "Mode d'authentification (déprécié, utilisez \"Site principal du compte\")",
       'x-i18n-title': {
-        fr: "Mode d'authentification",
-        en: 'Authentication mode',
-        es: 'Modo de autenticación',
-        it: 'Modalità di autenticazione',
-        pt: 'Modo de autenticação',
-        de: 'Authentifizierungsmodus'
+        fr: "Mode d'authentification (déprécié, utilisez \"Site principal du compte\")",
+        en: 'Authentication mode (deprecated, use "Main site of the account")',
+        es: 'Modo de autenticación (obsoleto, use "Sitio principal de la cuenta")',
+        it: 'Modalità di autenticazione (deprecata, usa "Sito principale dell\'account")',
+        pt: 'Modo de autenticação (obsoleto, use "Site principal da conta")',
+        de: 'Authentifizierungsmodus (veraltet, verwenden Sie "Hauptwebsite des Kontos")'
       },
       type: 'string',
       oneOf: [
@@ -158,19 +174,20 @@ export default {
       ]
     },
     authOnlyOtherSite: {
+      deprecated: true,
       layout: {
-        if: 'parent.data.authMode === "onlyOtherSite"',
+        if: 'parent.data.authMode === "onlyOtherSite" && !context.otherSites.some(s => s.isAccountMain) && !parent.data.isAccountMain',
         getItems: 'context.otherSites'
       },
       type: 'string',
-      title: "Autre site pour l'authentification",
+      title: "Autre site pour l'authentification (déprécié, utilisez \"Site principal du compte\")",
       'x-i18n-title': {
-        fr: "Autre site pour l'authentification",
-        en: 'Other site for authentication',
-        es: 'Otro sitio para autenticación',
-        it: 'Altro sito per l\'autenticazione',
-        pt: 'Outro site para autenticação',
-        de: 'Andere Website für die Authentifizierung'
+        fr: "Autre site pour l'authentification (déprécié, utilisez \"Site principal du compte\")",
+        en: 'Other site for authentication (deprecated, use "Main site of the account")',
+        es: 'Otro sitio para autenticación (obsoleto, use "Sitio principal de la cuenta")',
+        it: 'Altro sito per l\'autenticazione (deprecato, usa "Sito principale dell\'account")',
+        pt: 'Outro site para autenticação (obsoleto, use "Site principal da conta")',
+        de: 'Andere Website für die Authentifizierung (veraltet, verwenden Sie "Hauptwebsite des Kontos")'
       }
     },
     reducedPersonalInfoAtCreation: {

--- a/api/types/site/schema.js
+++ b/api/types/site/schema.js
@@ -109,7 +109,7 @@ export default {
     authMode: {
       deprecated: true,
       layout: {
-        if: '!context.otherSites.some(s => s.isAccountMain) && !parent.data.isAccountMain'
+        if: '!context.hasAccountMainSite && !parent.data.isAccountMain'
       },
       default: 'onlyBackOffice',
       title: "Mode d'authentification (déprécié, utilisez \"Site principal du compte\")",
@@ -176,7 +176,7 @@ export default {
     authOnlyOtherSite: {
       deprecated: true,
       layout: {
-        if: 'parent.data.authMode === "onlyOtherSite" && !context.otherSites.some(s => s.isAccountMain) && !parent.data.isAccountMain',
+        if: 'parent.data.authMode === "onlyOtherSite" && !context.hasAccountMainSite && !parent.data.isAccountMain',
         getItems: 'context.otherSites'
       },
       type: 'string',

--- a/ui/dts/typed-router.d.ts
+++ b/ui/dts/typed-router.d.ts
@@ -27,6 +27,7 @@ declare module 'vue-router/auto-routes' {
     '/admin/users': RouteRecordInfo<'/admin/users', '/admin/users', Record<never, never>, Record<never, never>>,
     '/contact': RouteRecordInfo<'/contact', '/contact', Record<never, never>, Record<never, never>>,
     '/create-organization': RouteRecordInfo<'/create-organization', '/create-organization', Record<never, never>, Record<never, never>>,
+    '/dev': RouteRecordInfo<'/dev', '/dev', Record<never, never>, Record<never, never>>,
     '/invitation': RouteRecordInfo<'/invitation', '/invitation', Record<never, never>, Record<never, never>>,
     '/login': RouteRecordInfo<'/login', '/login', Record<never, never>, Record<never, never>>,
     '/me': RouteRecordInfo<'/me', '/me', Record<never, never>, Record<never, never>>,

--- a/ui/src/components/layout/layout-app-bar.vue
+++ b/ui/src/components/layout/layout-app-bar.vue
@@ -82,7 +82,7 @@
         </v-menu>
       </template>
       <template
-        v-if="!isMainSite && (user?.adminMode || ($uiConfig.siteAdmin && siteRole === 'admin'))"
+        v-if="!isAccountMainSite && (user?.adminMode || ($uiConfig.siteAdmin && siteRole === 'admin'))"
       >
         <v-menu>
           <template #activator="{ props }">
@@ -151,5 +151,5 @@ import LangSwitcher from '@data-fair/lib-vuetify/lang-switcher.vue'
 import ThemeSwitcher from '@data-fair/lib-vuetify/theme-switcher.vue'
 
 const { user, organization, siteRole } = useSession()
-const { isMainSite } = useStore()
+const { isAccountMainSite } = useStore()
 </script>

--- a/ui/src/composables/use-store.ts
+++ b/ui/src/composables/use-store.ts
@@ -27,7 +27,7 @@ function createStore () {
 
   const host = window.location.host
   const mainPublicUrl = new URL($uiConfig.publicUrl)
-  const isMainSite = host === mainPublicUrl.host
+  const isAccountMainSite = host === mainPublicUrl.host
 
   return {
     sitePublic,
@@ -38,7 +38,7 @@ function createStore () {
     patchSite,
     host,
     mainPublicUrl,
-    isMainSite
+    isAccountMainSite
   }
 }
 

--- a/ui/src/pages/admin/sites/[id].vue
+++ b/ui/src/pages/admin/sites/[id].vue
@@ -69,6 +69,7 @@ const vjsfOptions = computed(() => {
     density: 'comfortable',
     initialValidation: 'always',
     context: {
+      hasAccountMainSite: otherSites?.some(s => s.isAccountMain),
       otherSites: otherSites?.map(site => site.host),
       otherSitesProviders: otherSites?.reduce((a, site) => { a[site.host] = (site.authProviders || []).filter(p => p.type === 'oidc').map(p => `${p.type}:${p.id}`); return a }, {} as Record<string, string[]>)
     }


### PR DESCRIPTION
The main site of an organization is meant to be the authentication domain and back-office for users of this organization.