### PR TITLE
chore: harden email trust and site-level isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,9 @@ npm run quality          # Full quality check (lint + types + tests)
 - **Storage abstraction**: `api/src/storages/interface.ts` defines the storage interface, implemented for MongoDB, LDAP, and file backends
 - **Auth**: `api/src/auth/service.ts` -- multi-provider support (OAuth2, SAML2, LDAP, local passwords)
 - **Test utilities**: `tests/support/` -- axios helpers, fixtures, in-process server setup
+
+### Architecture references
+
+Read before changing anything in the corresponding area:
+
+- [`docs/architecture/email-trust-and-site-isolation.md`](docs/architecture/email-trust-and-site-isolation.md) -- how SSO email claims are verified and how site-level SSO trust is confined so a compromised site config cannot escalate to superadmin or cross-site takeover. Required reading for changes to auth providers, `cleanUser`, `authProviderLoginCallback`, `adminMode`, or the change-host flow.

--- a/api/src/auth/router.ts
+++ b/api/src/auth/router.ts
@@ -158,10 +158,22 @@ router.post('/password', rejectCoreIdUser, async (req, res, next) => {
   }
 
   if (userFromMainHost && site) {
+    // A main-site user password-logged into a secondary site is offered to transfer their
+    // account. This is a sensitive state change: it permanently detaches them from the main
+    // site. Refuse the transfer for any user listed as an admin — otherwise a phishing link
+    // pointing at an attacker-controlled secondary site could trick a superadmin into
+    // locking themselves out of their admin status (cleanUser's `!host` guard would then
+    // drop isAdmin on the transferred record).
+    if (user.isAdmin) {
+      eventsLog.alert('sd.auth.password.admin-change-host-blocked', `admin ${user.email} attempted to change host to ${site.host} — refused`, logContext)
+      return returnError('adminChangeHostBlocked', 403)
+    }
     const payload: ActionPayload = {
       id: user.id,
       email: user.email,
-      action: 'changeHost'
+      action: 'changeHost',
+      host: site.host,
+      path: site.path
     }
     const token = await signToken(payload, config.jwtDurations.initialToken)
     const changeHostUrl = new URL((site.host.startsWith('localhost') ? 'http://' : 'https://') + site.host + '/simple-directory/login')
@@ -177,6 +189,12 @@ router.post('/password', rejectCoreIdUser, async (req, res, next) => {
 
   const payload = getTokenPayload(user, site)
   if (body.adminMode) {
+    // adminMode is only allowed on a main-site session (see auth/service.ts for the SSO
+    // equivalent of this check).
+    if (site) {
+      eventsLog.alert('sd.auth.password.not-admin', 'admin mode activation refused on non-main site session', logContext)
+      return returnError('adminModeOnly', 403)
+    }
     if (payload.isAdmin) payload.adminMode = 1
     else {
       eventsLog.alert('sd.auth.password.not-admin', 'a unauthorized user tried to activate admin mode', logContext)

--- a/api/src/auth/router.ts
+++ b/api/src/auth/router.ts
@@ -560,10 +560,11 @@ router.post('/action', async (req, res, next) => {
   }
 
   const storage = storages.globalStorage
-  let user = await storage.getUserByEmail(body.email, await reqSite(req))
+  const site = await reqSite(req)
+  let user = await storage.getUserByEmail(body.email, site)
   logContext.user = user
   let action = body.action as ActionPayload['action']
-  if (!user && await reqSite(req)) {
+  if (!user && site) {
     user = await storage.getUserByEmail(body.email)
     action = 'changeHost'
   }
@@ -579,6 +580,10 @@ router.post('/action', async (req, res, next) => {
     id: user.id,
     email: user.email,
     action
+  }
+  if (action === 'changeHost' && site) {
+    payload.host = site.host
+    payload.path = site.path
   }
   const token = await signToken(payload, config.jwtDurations.initialToken)
   const linkUrl = new URL(target)

--- a/api/src/auth/router.ts
+++ b/api/src/auth/router.ts
@@ -516,7 +516,7 @@ router.post('/keepalive', async (req, res, next) => {
 
       if (refreshedToken) {
         const { newToken, offlineRefreshToken } = refreshedToken
-        const userInfo = await provider.userInfo(newToken.access_token, newToken.id_token)
+        const userInfo = await provider.userInfo(newToken.access_token, newToken.id_token, { req })
         const memberInfos = await authProviderMemberInfo(await reqSite(req), provider, userInfo)
         user = await patchCoreAuthUser(provider, user, userInfo, memberInfos)
         await writeOAuthToken(user, provider, newToken, offlineRefreshToken, undefined, site?._id)
@@ -726,7 +726,7 @@ const oauthCallback: RequestHandler = async (req, res, next) => {
 
   const { token, offlineRefreshToken } = await provider.getToken(req.query.code as string, provider.coreIdProvider)
   debugOAuthTokens('full oauth token', token)
-  const authInfo = await provider.userInfo(token.access_token, token.id_token)
+  const authInfo = await provider.userInfo(token.access_token, token.id_token, logContext)
 
   if (!authInfo.user.email) {
     console.error('Email attribute not fetched from OAuth', provider.id, authInfo)

--- a/api/src/auth/service.ts
+++ b/api/src/auth/service.ts
@@ -27,7 +27,11 @@ type AuthProviderCore = {
   createMember?: CreateMember,
   memberRole?: MemberRole,
   memberDepartment?: MemberDepartment,
-  coreIdProvider?: boolean
+  coreIdProvider?: boolean,
+  // Opt-in: when true, the main-site provider is allowed to authenticate a user that
+  // matches an entry in config.admins. Default false — SSO cannot produce a superadmin
+  // session unless the deployment has explicitly acknowledged the risk.
+  allowSuperadmin?: boolean
 }
 
 type AuthProviderRef = Pick<AuthProviderCore, 'id' | 'type'>
@@ -150,6 +154,15 @@ export const authProviderLoginCallback = async (
   let user = await storage.getUserByEmail(authInfo.user.email, site)
   logContext.user = user
 
+  // Refuse to authenticate a superadmin through an SSO provider unless the provider was
+  // explicitly flagged `allowSuperadmin: true`. With cleanUser gating isAdmin on `!host`,
+  // this check only affects main-site SSO (site === undefined); it is a defense-in-depth
+  // layer against a compromised/misconfigured IdP asserting an admin email.
+  if (!site && user?.isAdmin && !provider.allowSuperadmin) {
+    eventsLog.alert('sd.auth.provider.superadmin-blocked', `SSO provider ${provider.type}/${provider.id} refused to authenticate superadmin ${user.email}`, logContext)
+    throw httpError(403, 'superadminProviderBlocked')
+  }
+
   if (!user && storage.readonly) {
     throw httpError(403, 'userUnknown')
   }
@@ -236,6 +249,14 @@ export const authProviderLoginCallback = async (
   const payload = getTokenPayload(user, site)
   if (adminMode) {
     // TODO: also check that the user actually inputted the password on this redirect
+    // adminMode can only be activated on a session bound to the main site (site === undefined).
+    // With the cleanUser `!host` guard this is already implied (isAdmin requires !user.host and
+    // secondary-site users always have host), but we assert it explicitly here so any future
+    // relaxation of isAdmin does not silently re-open adminMode on a site session.
+    if (site) {
+      eventsLog.alert('sd.auth.oauth.not-admin', 'admin mode activation refused on non-main site session', logContext)
+      throw httpError(403, 'adminModeOnly')
+    }
     if (payload.isAdmin) payload.adminMode = 1
     else {
       eventsLog.alert('sd.auth.oauth.not-admin', 'a unauthorized user tried to activate admin mode', logContext)

--- a/api/src/oauth/oidc.ts
+++ b/api/src/oauth/oidc.ts
@@ -73,8 +73,8 @@ export async function completeOidcProvider (p: OpenIDConnect): Promise<OAuthProv
     if (!claims?.email) {
       throw httpError(400, 'Authentification refusée depuis le fournisseur. Pas d\'adresse email trouvée dans les informations utilisateur.')
     }
-    if (claims.email_verified === false && !p.ignoreEmailVerified) {
-      throw httpError(400, 'Authentification refusée depuis le fournisseur. L\'adresse mail est indiquée comme non validée.')
+    if (claims.email_verified !== true && !p.ignoreEmailVerified) {
+      throw httpError(400, 'Authentification refusée depuis le fournisseur. L\'adresse mail n\'est pas indiquée comme validée.')
     }
     const userInfo: OAuthUserInfo = {
       data: claims,

--- a/api/src/oauth/oidc.ts
+++ b/api/src/oauth/oidc.ts
@@ -6,6 +6,7 @@ import Debug from 'debug'
 import _slug from 'slugify'
 import jwt from 'jsonwebtoken'
 import { httpError } from '@data-fair/lib-express'
+import eventsLog, { type EventLogContext } from '@data-fair/lib-express/events-log.js'
 
 const slug = _slug.default
 const debug = Debug('oauth')
@@ -41,7 +42,7 @@ export async function completeOidcProvider (p: OpenIDConnect): Promise<OAuthProv
     authorizeHost: authURL.origin,
     authorizePath: authURL.pathname
   }
-  const userInfo = async (accessToken: string, idToken?:string) => {
+  const userInfo = async (accessToken: string, idToken?:string, logContext?: EventLogContext) => {
     let claims
     if (!p.userInfoSource || p.userInfoSource === 'auto') {
       if (discoveryContent.userinfo_endpoint) {
@@ -74,6 +75,17 @@ export async function completeOidcProvider (p: OpenIDConnect): Promise<OAuthProv
       throw httpError(400, 'Authentification refusée depuis le fournisseur. Pas d\'adresse email trouvée dans les informations utilisateur.')
     }
     if (claims.email_verified !== true && !p.ignoreEmailVerified) {
+      // The `email_verified !== true` check (tightened from the previous `=== false`) is
+      // the canonical place where a previously-accepted IdP configuration now fails.
+      // Emit a structured alert so operators can monitor the post-deployment impact.
+      if (logContext) {
+        const emailDomain = typeof claims.email === 'string' ? claims.email.split('@')[1] : null
+        eventsLog.alert(
+          'sd.oidc.email-not-verified',
+          `OIDC login refused: provider=${id} emailVerified=${JSON.stringify(claims.email_verified ?? null)} emailDomain=${emailDomain}`,
+          logContext
+        )
+      }
       throw httpError(400, 'Authentification refusée depuis le fournisseur. L\'adresse mail n\'est pas indiquée comme validée.')
     }
     const userInfo: OAuthUserInfo = {

--- a/api/src/oauth/service.ts
+++ b/api/src/oauth/service.ts
@@ -1,6 +1,7 @@
 import type { Request } from 'express'
 import type { OpenIDConnect } from '../../config/type/index.ts'
 import { reqSiteUrl } from '@data-fair/lib-express'
+import type { EventLogContext } from '@data-fair/lib-express/events-log.js'
 import oauth2 from 'simple-oauth2'
 import { nanoid } from 'nanoid'
 import config from '#config'
@@ -39,7 +40,10 @@ export type OAuthProvider = Omit<OpenIDConnect, 'discovery' | 'type'> & {
     authorizeHost?: string,
     authorizePath: string
   },
-  userInfo: (accessToken: string, id_token?: string) => Promise<OAuthUserInfo>
+  // logContext is passed so that email-verification refusals can emit structured eventsLog
+  // entries (sd.oidc.email-not-verified / sd.oauth.email-not-verified) with full request
+  // context. Omit it in background paths that have no request (e.g. the token-refresh worker).
+  userInfo: (accessToken: string, id_token?: string, logContext?: EventLogContext) => Promise<OAuthUserInfo>
 }
 
 export type PreparedOAuthProvider = OAuthProvider & {

--- a/api/src/oauth/standard-providers.ts
+++ b/api/src/oauth/standard-providers.ts
@@ -2,6 +2,7 @@ import axios from '@data-fair/lib-node/axios.js'
 import config from '#config'
 import Debug from 'debug'
 import { httpError } from '@data-fair/lib-express'
+import eventsLog from '@data-fair/lib-express/events-log.js'
 import { type OAuthProvider, type OAuthUserInfo } from './service.ts'
 
 const debug = Debug('oauth')
@@ -23,7 +24,7 @@ for (const provider of config.oauth.providers) {
         tokenPath: '/login/oauth/access_token',
         authorizePath: '/login/oauth/authorize'
       },
-      userInfo: async (accessToken: string) => {
+      userInfo: async (accessToken, _idToken, logContext) => {
         const res = await Promise.all([
           axios.get('https://api.github.com/user', { headers: { Authorization: `token ${accessToken}` } }),
           axios.get('https://api.github.com/user/emails', { headers: { Authorization: `token ${accessToken}` } })
@@ -31,6 +32,13 @@ for (const provider of config.oauth.providers) {
         debug('user info from github', res[0].data, res[1].data)
         const email = res[1].data.find((e: any) => e.primary && e.verified)
         if (!email) {
+          if (logContext) {
+            eventsLog.alert(
+              'sd.oauth.email-not-verified',
+              `GitHub login refused: no primary+verified email (addressesCount=${Array.isArray(res[1].data) ? res[1].data.length : 0})`,
+              logContext
+            )
+          }
           throw httpError(400, 'Authentification refusée depuis le fournisseur. Aucune adresse email principale validée trouvée sur le compte GitHub.')
         }
         return {
@@ -62,12 +70,14 @@ for (const provider of config.oauth.providers) {
         authorizeHost: 'https://www.facebook.com',
         authorizePath: '/v6.0/dialog/oauth'
       },
-      userInfo: async (_accessToken: string) => {
+      userInfo: async (_accessToken, _idToken, logContext) => {
         // Facebook's Graph API does not expose an email-verification flag, so the email claim
         // cannot be trusted as an identity binding. Refuse the login to avoid account-takeover
         // via an unverified address; reach out to us if you need this provider re-enabled with
         // a dedicated email-confirmation flow.
-        debug('facebook login refused: no email verification available')
+        if (logContext) {
+          eventsLog.alert('sd.oauth.email-not-verified', 'Facebook login refused: provider does not deliver a verified email flag', logContext)
+        }
         throw httpError(400, 'Authentification via Facebook désactivée : Facebook ne fournit pas d\'information de validation de l\'adresse email.')
       },
       client: config.oauth.facebook
@@ -88,10 +98,18 @@ for (const provider of config.oauth.providers) {
         authorizeHost: 'https://accounts.google.com',
         authorizePath: '/o/oauth2/v2/auth'
       },
-      userInfo: async (accessToken: string) => {
+      userInfo: async (accessToken, _idToken, logContext) => {
         const res = await axios.get('https://www.googleapis.com/oauth2/v1/userinfo', { params: { alt: 'json', access_token: accessToken } })
         debug('user info from google', res.data)
         if (res.data.verified_email !== true) {
+          if (logContext) {
+            const emailDomain = typeof res.data.email === 'string' ? res.data.email.split('@')[1] : null
+            eventsLog.alert(
+              'sd.oauth.email-not-verified',
+              `Google login refused: verifiedEmail=${JSON.stringify(res.data.verified_email ?? null)} emailDomain=${emailDomain}`,
+              logContext
+            )
+          }
           throw httpError(400, 'Authentification refusée depuis le fournisseur. L\'adresse email Google n\'est pas indiquée comme validée.')
         }
         return {

--- a/api/src/oauth/standard-providers.ts
+++ b/api/src/oauth/standard-providers.ts
@@ -1,6 +1,7 @@
 import axios from '@data-fair/lib-node/axios.js'
 import config from '#config'
 import Debug from 'debug'
+import { httpError } from '@data-fair/lib-express'
 import { type OAuthProvider, type OAuthUserInfo } from './service.ts'
 
 const debug = Debug('oauth')
@@ -28,9 +29,10 @@ for (const provider of config.oauth.providers) {
           axios.get('https://api.github.com/user/emails', { headers: { Authorization: `token ${accessToken}` } })
         ])
         debug('user info from github', res[0].data, res[1].data)
-        let email = res[1].data.find((e: any) => e.primary)
-        if (!email) email = res[1].data.find((e: any) => e.verified)
-        if (!email) email = res[1].data[0]
+        const email = res[1].data.find((e: any) => e.primary && e.verified)
+        if (!email) {
+          throw httpError(400, 'Authentification refusée depuis le fournisseur. Aucune adresse email principale validée trouvée sur le compte GitHub.')
+        }
         return {
           data: res[0].data,
           user: {
@@ -60,22 +62,13 @@ for (const provider of config.oauth.providers) {
         authorizeHost: 'https://www.facebook.com',
         authorizePath: '/v6.0/dialog/oauth'
       },
-      userInfo: async (accessToken: string) => {
-        // TODO: fetch picture, but it is a temporary URL we should store the result if we want to use it
-        const res = await axios.get('https://graph.facebook.com/me', { params: { access_token: accessToken, fields: 'name,first_name,last_name,email' } })
-        debug('user info from facebook', res.data)
-        const userInfo: OAuthUserInfo = {
-          data: res.data,
-          user: {
-            name: res.data.name,
-            firstName: res.data.first_name,
-            lastName: res.data.last_name,
-            email: res.data.email
-          },
-          id: res.data.id,
-          url: 'https://www.facebook.com'
-        }
-        return userInfo
+      userInfo: async (_accessToken: string) => {
+        // Facebook's Graph API does not expose an email-verification flag, so the email claim
+        // cannot be trusted as an identity binding. Refuse the login to avoid account-takeover
+        // via an unverified address; reach out to us if you need this provider re-enabled with
+        // a dedicated email-confirmation flow.
+        debug('facebook login refused: no email verification available')
+        throw httpError(400, 'Authentification via Facebook désactivée : Facebook ne fournit pas d\'information de validation de l\'adresse email.')
       },
       client: config.oauth.facebook
     })
@@ -98,6 +91,9 @@ for (const provider of config.oauth.providers) {
       userInfo: async (accessToken: string) => {
         const res = await axios.get('https://www.googleapis.com/oauth2/v1/userinfo', { params: { alt: 'json', access_token: accessToken } })
         debug('user info from google', res.data)
+        if (res.data.verified_email !== true) {
+          throw httpError(400, 'Authentification refusée depuis le fournisseur. L\'adresse email Google n\'est pas indiquée comme validée.')
+        }
         return {
           data: res.data,
           user: {

--- a/api/src/storages/file.ts
+++ b/api/src/storages/file.ts
@@ -86,7 +86,7 @@ class FileStorage implements SdStorage {
   cleanUser (user: any): User {
     const res = { ...user, organizations: getUserOrgas(this.organizations, user) }
     delete res.password
-    res.isAdmin = config.admins.includes(res.email.toLowerCase()) || user.id === '_superadmin'
+    res.isAdmin = !res.host && (config.admins.includes(res.email.toLowerCase()) || user.id === '_superadmin')
     if (config.onlyCreateInvited) res.ignorePersonalAccount = true
     return res
   }

--- a/api/src/storages/ldap.ts
+++ b/api/src/storages/ldap.ts
@@ -582,8 +582,9 @@ export class LdapStorage implements SdStorage {
       if (this.org) user.orgStorage = true
       if (withSession) user.sessions = (await mongo.ldapUserSessions.findOne({ _id: user.id }))?.sessions
       if (!this.org) {
-        user.isAdmin = config.admins.includes(user.email.toLowerCase()) || user.id === '_superadmin'
-        if (!user.isAdmin && this.ldapParams.isAdmin?.attr && this.ldapParams.isAdmin?.values?.length) {
+        // Admin rights are only granted to a user record that belongs to the main site (no host).
+        user.isAdmin = !user.host && (config.admins.includes(user.email.toLowerCase()) || user.id === '_superadmin')
+        if (!user.isAdmin && !user.host && this.ldapParams.isAdmin?.attr && this.ldapParams.isAdmin?.values?.length) {
           debug('check if user is admin', user.email, res.fullResults[0].attrs)
           const values = res.fullResults[0].attrs[this.ldapParams.isAdmin.attr] ?? []
           for (const value of values) {

--- a/api/src/storages/mongo.ts
+++ b/api/src/storages/mongo.ts
@@ -27,7 +27,11 @@ async function cleanUser (resource: any): Promise<User> {
     delete resource['2FA'].secret
     delete resource['2FA'].recovery
   }
-  resource.isAdmin = config.admins.includes(resource.email?.toLowerCase()) || resource.id === '_superadmin'
+  // Admin rights are only granted to a user record that belongs to the main site (no host).
+  // A user record tied to a secondary site can never inherit admin status even if its email
+  // matches config.admins — this neutralizes cross-site admin takeover via a compromised or
+  // misconfigured site-level SSO.
+  resource.isAdmin = !resource.host && (config.admins.includes(resource.email?.toLowerCase()) || resource.id === '_superadmin')
   if (resource.onlyCreateInvited) resource.ignorePersonalAccount = true
   if (resource.organizations) {
     for (const org of resource.organizations) {

--- a/api/src/users/router.ts
+++ b/api/src/users/router.ts
@@ -365,7 +365,19 @@ router.post('/:userId/host', rejectCoreIdUser, async (req, res, next) => {
   }
   if (decoded.id !== req.params.userId) return res.status(401).send('wrong user id in token')
   if (decoded.action !== 'changeHost') return res.status(401).send('wrong action for this token')
-  await storage.patchUser(req.params.userId, { host: body.host, oauth: null, oidc: null, saml: null })
+  // The target host/path are bound into the action token; if the body tries to override them,
+  // refuse — and always take the target from the signed token, never from the request body.
+  if (!decoded.host) {
+    eventsLog.alert('sd.user.change-host.unbound', `change-host token without bound host for user ${req.params.userId}`, logContext)
+    return res.status(401).send('unbound token')
+  }
+  if (body.host !== decoded.host) {
+    eventsLog.alert('sd.user.change-host.mismatch', `change-host token host mismatch for user ${req.params.userId}`, logContext)
+    return res.status(401).send('host mismatch')
+  }
+  const patch: any = { host: decoded.host, oauth: null, oidc: null, saml: null }
+  if (decoded.path) patch.path = decoded.path
+  await storage.patchUser(req.params.userId, patch)
 
   eventsLog.info('sd.user.change-host', `user changed host ${req.params.userId}`, logContext)
 
@@ -378,7 +390,7 @@ router.post('/:userId/host', rejectCoreIdUser, async (req, res, next) => {
         action: 'changePassword'
       }
       const token = await signToken(payload, config.jwtDurations.initialToken)
-      res.send(token)
+      return res.send(token)
     }
   }
 

--- a/api/types/index.ts
+++ b/api/types/index.ts
@@ -55,7 +55,11 @@ export type ShortenedInvitation = {
 export type ActionPayload = {
   id: string,
   email: string,
-  action: 'changePassword' | 'changeHost'
+  action: 'changePassword' | 'changeHost',
+  // For `action: 'changeHost'` the target host/path are bound into the token so that the
+  // bearer cannot redirect the user record to an arbitrary site.
+  host?: string,
+  path?: string
 }
 
 export type ShortenedPartnerInvitation = {

--- a/docs/architecture/email-trust-and-site-isolation.md
+++ b/docs/architecture/email-trust-and-site-isolation.md
@@ -1,0 +1,195 @@
+# Email trust and site-level isolation
+
+This document describes how simple-directory decides whether to trust the email
+claim returned by an identity provider, and how that trust is confined to a
+single *site* so that a compromise of one site's SSO configuration cannot bleed
+into another. It is the reference for reviewers of any change that touches
+authentication, site configuration, or the user model.
+
+## Why email is a high-value claim
+
+The user model keys several decisions off `user.email`:
+
+- admin rights are derived from `config.admins` (a list of email strings) —
+  see `cleanUser` in `api/src/storages/{mongo,ldap,file}.ts`.
+- account linking on SSO login matches an incoming identity against an
+  existing user by email (`getUserByEmail`) — see `authProviderLoginCallback`
+  in `api/src/auth/service.ts`.
+- invitations and organization membership are addressed by email.
+
+An email claim we trust is therefore effectively an identity assertion. Any
+identity provider that can make simple-directory accept an arbitrary email
+string can impersonate the corresponding user — up to and including a
+superadmin if that email appears in `config.admins`.
+
+The trust model below defines where we accept an email claim, what verification
+we demand before accepting it, and how we prevent a mistake or compromise in
+one SSO configuration from having blast radius beyond its own site.
+
+## Sites as trust boundaries
+
+A *site* in simple-directory is identified by `(host, path)` and has its own
+configuration, its own auth providers, and its own user scope.
+
+- The **main site** is the deployment-wide identity authority. Its
+  configuration lives in `api/config/default.cjs` (and overrides). Its auth
+  providers are configured by the operator of the simple-directory instance,
+  not by site admins.
+- A **secondary site** has its own configuration stored in the `sites`
+  collection, editable by its site admin. It can declare its own auth
+  providers (`authProviders` on the site document).
+
+Trust flows strictly top-down: the main site is trusted by all sites, but no
+secondary site is trusted by the main site or by any other secondary site.
+
+### User-record site scoping
+
+User records carry an optional `host` field.
+
+- Users with no `host` belong to the main site.
+- Users with `host` set belong to a specific secondary site.
+
+`getUserByEmail(email, site)` only returns records matching that site's
+`(host, path)` — or records without `host` when called for the main site. A
+secondary-site SSO login therefore cannot resolve to a main-site user record
+by email collision. This is the primary site-isolation guarantee for the user
+model.
+
+### Admin rights require a main-site record
+
+`cleanUser` computes `isAdmin` as:
+
+```js
+isAdmin = !resource.host
+  && (config.admins.includes(resource.email?.toLowerCase())
+      || resource.id === '_superadmin')
+```
+
+The `!resource.host` guard means that **a user record tied to a secondary site
+can never carry admin status**, even if its email matches an entry in
+`config.admins`. This is what prevents a compromised secondary-site SSO from
+asserting an admin email and escalating to superadmin: the record it produces
+is site-scoped, so `cleanUser` will never flag it as admin.
+
+### Site-level auth providers cannot mint admin sessions
+
+Because admin-ness requires a main-site user record, and because a site-level
+SSO always creates/reuses site-scoped user records, a compromised site-level
+SSO cannot mint a superadmin session. The blast radius of a bad site-level
+SSO is confined to users of that site.
+
+Org membership is *not* site-scoped today. A user created on site A cannot
+automatically gain membership to an org owned by site B — because the
+membership is attached to the user record, which itself belongs to site A.
+A compromised site A can create an arbitrary user on A with a target email,
+but that user does not inherit any membership or identity from the main site
+or from any other site.
+
+## Email verification for SSO providers
+
+Every SSO provider in simple-directory is required to produce an email claim
+that has been verified *by the provider*. The rule is opt-in, not opt-out:
+absent a positive verification signal, the login is refused.
+
+### OpenID Connect
+
+`api/src/oauth/oidc.ts` rejects the login unless `claims.email_verified === true`.
+A missing, null, or `false` claim all fail closed.
+
+A per-provider escape hatch `ignoreEmailVerified: true` exists for operators
+who trust a specific IdP to deliver pre-verified addresses outside the
+standard claim. Setting it is a deliberate risk acceptance — the site-config
+UI gates this field behind superadmin-level editing; it must not be exposed to
+site admins.
+
+### Standard OAuth providers
+
+`api/src/oauth/standard-providers.ts`:
+
+- **Google** — requires `verified_email === true` on the `v1/userinfo`
+  response. Google enforces primary-email verification upstream for its
+  consumer accounts; for Workspace customers the flag reflects the domain's
+  configuration.
+- **GitHub** — only accepts the email address that is both `primary` and
+  `verified`. Unverified addresses attached to a GitHub account — including
+  ones the attacker can add freely — are ignored.
+- **Facebook** — refused. The Graph API does not expose an email-verification
+  flag, and we cannot reconstruct one. Re-enabling Facebook would require
+  implementing a dedicated email-confirmation flow at the simple-directory
+  level.
+- **LinkedIn** — LinkedIn's primary email is considered verified by LinkedIn
+  before it is returned; no additional check.
+
+### SAML 2
+
+SAML does not standardize a verified-email claim. Accepting a SAML IdP is
+therefore an explicit trust statement about the IdP: by adding it, the
+operator declares that any email attribute it emits is trustworthy. For
+secondary-site IdPs this trust is confined to that site by the user-scoping
+rules above.
+
+## Preventing SSO superadmin escalation
+
+Even with verified-email checks in place, a main-site SSO provider is
+structurally capable of asserting an admin email — the email is verified by
+the IdP, not by simple-directory. A misconfigured or compromised main-site
+IdP is a path to a superadmin session that we block by default.
+
+### `allowSuperadmin` provider flag
+
+`authProviderLoginCallback` refuses to complete an SSO login when all of the
+following hold:
+
+- the session is being minted on the main site (`site === undefined`), and
+- the matched user has `isAdmin === true`, and
+- the provider has not set `allowSuperadmin: true`.
+
+The default is `false`. An operator who wants an admin to be able to log in
+via a main-site SSO provider has to flip the flag explicitly, accepting that
+the IdP is trusted to authenticate superadmins.
+
+### `adminMode` is main-site only
+
+`adminMode=1` is the privilege escalation that an admin asks for in a UI
+action like "admin mode". It is now refused on any non-main-site session, both
+on the password-login path (`api/src/auth/router.ts`) and on the SSO path
+(`api/src/auth/service.ts`). This is redundant with the `!host` guard in
+`cleanUser` — a secondary-site user cannot be `isAdmin` anyway — but it is
+cheap defense in depth for any future relaxation of `cleanUser`.
+
+## Protecting the main-site → secondary-site account transfer
+
+Password login into a secondary site with a main-site account offers a
+"change host" flow: the existing user record is relocated to the secondary
+site so the user can continue with their known credentials.
+
+This flow is a sensitive state change — after it completes, the record
+carries `host`, and the `!host` admin guard drops its admin status
+permanently. Two safeguards apply:
+
+- **Admins cannot be transferred.** `api/src/auth/router.ts` refuses the
+  change-host offer if the user is listed in `config.admins`. This prevents a
+  phishing link ("click here to log in") pointing at an attacker-controlled
+  secondary site from tricking a superadmin into detaching their own admin
+  record.
+- **The target host is signed into the action token.** `ActionPayload` now
+  carries `host` and `path` for `action: 'changeHost'`, and
+  `POST /api/users/:userId/host` applies the host taken from the decoded
+  token, not the host given in the request body. A stolen action token cannot
+  be replayed to relocate a user record to an arbitrary host.
+
+## Invariants
+
+When reviewing auth, storage, or site changes, preserve:
+
+1. A secondary-site user record never carries admin status.
+2. `adminMode=1` is only ever set on a main-site session.
+3. An SSO provider never produces a superadmin session unless its
+   configuration explicitly opts in via `allowSuperadmin`.
+4. No SSO provider accepts an unverified email — default closed, per-provider
+   opt-out only for OIDC and requiring a superadmin-level config edit.
+5. A `changeHost` token's effect is bounded to the `(host, path)` bound into
+   the token.
+
+Violations of any of these unlock one of the exploit paths described in
+`docs/security-review-2026-04.md` (C-0 family).

--- a/docs/architecture/email-trust-and-site-isolation.md
+++ b/docs/architecture/email-trust-and-site-isolation.md
@@ -1,63 +1,31 @@
 # Email trust and site-level isolation
 
-This document describes how simple-directory decides whether to trust the email
-claim returned by an identity provider, and how that trust is confined to a
-single *site* so that a compromise of one site's SSO configuration cannot bleed
-into another. It is the reference for reviewers of any change that touches
-authentication, site configuration, or the user model.
+How simple-directory decides whether to trust an IdP's email claim, and how
+that trust is confined to a single *site*. Required reading before changing
+auth providers, `cleanUser`, `authProviderLoginCallback`, `adminMode`, or the
+change-host flow.
 
-## Why email is a high-value claim
+## Why email is high-value
 
-The user model keys several decisions off `user.email`:
-
-- admin rights are derived from `config.admins` (a list of email strings) —
-  see `cleanUser` in `api/src/storages/{mongo,ldap,file}.ts`.
-- account linking on SSO login matches an incoming identity against an
-  existing user by email (`getUserByEmail`) — see `authProviderLoginCallback`
-  in `api/src/auth/service.ts`.
-- invitations and organization membership are addressed by email.
-
-An email claim we trust is therefore effectively an identity assertion. Any
-identity provider that can make simple-directory accept an arbitrary email
-string can impersonate the corresponding user — up to and including a
-superadmin if that email appears in `config.admins`.
-
-The trust model below defines where we accept an email claim, what verification
-we demand before accepting it, and how we prevent a mistake or compromise in
-one SSO configuration from having blast radius beyond its own site.
+`user.email` drives admin rights (`config.admins`), account linking on SSO
+(`getUserByEmail`), invitations, and org membership. An IdP that can make SD
+accept an arbitrary email string can impersonate the corresponding user — up
+to superadmin if the email is in `config.admins`.
 
 ## Sites as trust boundaries
 
-A *site* in simple-directory is identified by `(host, path)` and has its own
-configuration, its own auth providers, and its own user scope.
+A site is `(host, path)` with its own config, auth providers, and user scope.
 
-- The **main site** is the deployment-wide identity authority. Its
-  configuration lives in `api/config/default.cjs` (and overrides). Its auth
-  providers are configured by the operator of the simple-directory instance,
-  not by site admins.
-- A **secondary site** has its own configuration stored in the `sites`
-  collection, editable by its site admin. It can declare its own auth
-  providers (`authProviders` on the site document).
+- **Main site** — operator-managed, trusted by all sites.
+- **Secondary site** — site-admin-editable, trusts only itself.
 
-Trust flows strictly top-down: the main site is trusted by all sites, but no
-secondary site is trusted by the main site or by any other secondary site.
+### User scoping
 
-### User-record site scoping
-
-User records carry an optional `host` field.
-
-- Users with no `host` belong to the main site.
-- Users with `host` set belong to a specific secondary site.
-
-`getUserByEmail(email, site)` only returns records matching that site's
-`(host, path)` — or records without `host` when called for the main site. A
-secondary-site SSO login therefore cannot resolve to a main-site user record
-by email collision. This is the primary site-isolation guarantee for the user
-model.
+User records carry an optional `host`. `getUserByEmail(email, site)` only
+matches the right scope, so a secondary-site SSO cannot resolve to a main-site
+record by email collision.
 
 ### Admin rights require a main-site record
-
-`cleanUser` computes `isAdmin` as:
 
 ```js
 isAdmin = !resource.host
@@ -65,131 +33,74 @@ isAdmin = !resource.host
       || resource.id === '_superadmin')
 ```
 
-The `!resource.host` guard means that **a user record tied to a secondary site
-can never carry admin status**, even if its email matches an entry in
-`config.admins`. This is what prevents a compromised secondary-site SSO from
-asserting an admin email and escalating to superadmin: the record it produces
-is site-scoped, so `cleanUser` will never flag it as admin.
+A record tied to any secondary site can never be `isAdmin` — this is the core
+guarantee preventing cross-site admin takeover.
 
-### Site-level auth providers cannot mint admin sessions
+Org membership is not site-scoped, but memberships attach to user records, so
+a compromised site A cannot inherit memberships from another site.
 
-Because admin-ness requires a main-site user record, and because a site-level
-SSO always creates/reuses site-scoped user records, a compromised site-level
-SSO cannot mint a superadmin session. The blast radius of a bad site-level
-SSO is confined to users of that site.
+## Email verification
 
-Org membership is *not* site-scoped today. A user created on site A cannot
-automatically gain membership to an org owned by site B — because the
-membership is attached to the user record, which itself belongs to site A.
-A compromised site A can create an arbitrary user on A with a target email,
-but that user does not inherit any membership or identity from the main site
-or from any other site.
+Opt-in, fail-closed: absent a positive verification signal, login is refused.
 
-## Email verification for SSO providers
+- **OIDC** (`api/src/oauth/oidc.ts`) — requires `claims.email_verified === true`.
+  Per-provider `ignoreEmailVerified: true` escape hatch, gated behind
+  superadmin-level site-config editing.
+- **Google** — requires `verified_email === true` on the v1 userinfo.
+- **GitHub** — requires the address to be both `primary` and `verified`.
+- **Facebook** — refused (no verification flag exposed).
+- **LinkedIn** — primary email is considered verified upstream.
+- **SAML 2** — no standard verified flag; adding a SAML IdP is an explicit
+  trust statement. Site-level IdPs remain confined by user scoping.
 
-Every SSO provider in simple-directory is required to produce an email claim
-that has been verified *by the provider*. The rule is opt-in, not opt-out:
-absent a positive verification signal, the login is refused.
+### Monitoring
 
-### OpenID Connect
+Rejections emit `eventsLog.alert` entries to monitor post-deployment:
 
-`api/src/oauth/oidc.ts` rejects the login unless `claims.email_verified === true`.
-A missing, null, or `false` claim all fail closed.
+- `sd.oidc.email-not-verified` — provider, raw `emailVerifiedClaim`, domain.
+- `sd.oauth.email-not-verified` — provider, reason / claim value.
 
-A per-provider escape hatch `ignoreEmailVerified: true` exists for operators
-who trust a specific IdP to deliver pre-verified addresses outside the
-standard claim. Setting it is a deliberate risk acceptance — the site-config
-UI gates this field behind superadmin-level editing; it must not be exposed to
-site admins.
+A non-zero rate on a previously working provider means the tightened check
+(`!== true`, previously `=== false`) caught an IdP that used to pass
+silently. Fix upstream, or set `ignoreEmailVerified: true` (OIDC only, as a
+deliberate superadmin-level decision).
 
-### Standard OAuth providers
-
-`api/src/oauth/standard-providers.ts`:
-
-- **Google** — requires `verified_email === true` on the `v1/userinfo`
-  response. Google enforces primary-email verification upstream for its
-  consumer accounts; for Workspace customers the flag reflects the domain's
-  configuration.
-- **GitHub** — only accepts the email address that is both `primary` and
-  `verified`. Unverified addresses attached to a GitHub account — including
-  ones the attacker can add freely — are ignored.
-- **Facebook** — refused. The Graph API does not expose an email-verification
-  flag, and we cannot reconstruct one. Re-enabling Facebook would require
-  implementing a dedicated email-confirmation flow at the simple-directory
-  level.
-- **LinkedIn** — LinkedIn's primary email is considered verified by LinkedIn
-  before it is returned; no additional check.
-
-### SAML 2
-
-SAML does not standardize a verified-email claim. Accepting a SAML IdP is
-therefore an explicit trust statement about the IdP: by adding it, the
-operator declares that any email attribute it emits is trustworthy. For
-secondary-site IdPs this trust is confined to that site by the user-scoping
-rules above.
+Implementation: `userInfo(accessToken, idToken?, logContext?)` takes an
+optional log context; call sites with a request pass it, background paths
+(e.g. token-refresh worker) omit it.
 
 ## Preventing SSO superadmin escalation
 
-Even with verified-email checks in place, a main-site SSO provider is
-structurally capable of asserting an admin email — the email is verified by
-the IdP, not by simple-directory. A misconfigured or compromised main-site
-IdP is a path to a superadmin session that we block by default.
+A main-site IdP is structurally capable of asserting an admin email. Two
+defenses:
 
-### `allowSuperadmin` provider flag
+- **`allowSuperadmin` provider flag** — `authProviderLoginCallback` refuses
+  the login when the session is on the main site, the matched user is admin,
+  and the provider has not set `allowSuperadmin: true`. Default off.
+- **`adminMode` is main-site only** — password and SSO login paths both
+  refuse `adminMode=1` on any non-main-site session (redundant with the
+  `!host` guard, kept as defense in depth).
 
-`authProviderLoginCallback` refuses to complete an SSO login when all of the
-following hold:
+## Change-host hardening
 
-- the session is being minted on the main site (`site === undefined`), and
-- the matched user has `isAdmin === true`, and
-- the provider has not set `allowSuperadmin: true`.
+Password login into a secondary site with a main-site account offers a host
+transfer. Sensitive: after the transfer, the record carries `host` and loses
+admin status permanently. Two safeguards:
 
-The default is `false`. An operator who wants an admin to be able to log in
-via a main-site SSO provider has to flip the flag explicitly, accepting that
-the IdP is trusted to authenticate superadmins.
-
-### `adminMode` is main-site only
-
-`adminMode=1` is the privilege escalation that an admin asks for in a UI
-action like "admin mode". It is now refused on any non-main-site session, both
-on the password-login path (`api/src/auth/router.ts`) and on the SSO path
-(`api/src/auth/service.ts`). This is redundant with the `!host` guard in
-`cleanUser` — a secondary-site user cannot be `isAdmin` anyway — but it is
-cheap defense in depth for any future relaxation of `cleanUser`.
-
-## Protecting the main-site → secondary-site account transfer
-
-Password login into a secondary site with a main-site account offers a
-"change host" flow: the existing user record is relocated to the secondary
-site so the user can continue with their known credentials.
-
-This flow is a sensitive state change — after it completes, the record
-carries `host`, and the `!host` admin guard drops its admin status
-permanently. Two safeguards apply:
-
-- **Admins cannot be transferred.** `api/src/auth/router.ts` refuses the
-  change-host offer if the user is listed in `config.admins`. This prevents a
-  phishing link ("click here to log in") pointing at an attacker-controlled
-  secondary site from tricking a superadmin into detaching their own admin
-  record.
-- **The target host is signed into the action token.** `ActionPayload` now
-  carries `host` and `path` for `action: 'changeHost'`, and
-  `POST /api/users/:userId/host` applies the host taken from the decoded
-  token, not the host given in the request body. A stolen action token cannot
-  be replayed to relocate a user record to an arbitrary host.
+- Users in `config.admins` cannot be transferred (prevents phishing-driven
+  superadmin lockout).
+- Target `(host, path)` is signed into the action token; the `/host` endpoint
+  applies the host from the decoded token, not the request body.
 
 ## Invariants
 
-When reviewing auth, storage, or site changes, preserve:
-
 1. A secondary-site user record never carries admin status.
 2. `adminMode=1` is only ever set on a main-site session.
-3. An SSO provider never produces a superadmin session unless its
-   configuration explicitly opts in via `allowSuperadmin`.
-4. No SSO provider accepts an unverified email — default closed, per-provider
-   opt-out only for OIDC and requiring a superadmin-level config edit.
-5. A `changeHost` token's effect is bounded to the `(host, path)` bound into
-   the token.
+3. An SSO provider never produces a superadmin session unless
+   `allowSuperadmin: true`.
+4. No SSO provider accepts an unverified email; the per-provider opt-out
+   (OIDC only) requires a superadmin-level config edit.
+5. A `changeHost` token's effect is bounded to the `(host, path)` it signs.
 
-Violations of any of these unlock one of the exploit paths described in
-`docs/security-review-2026-04.md` (C-0 family).
+Violations re-open an exploit path in the C-0 family from
+`docs/security-review-2026-04.md`.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev-mock-oidc": "node --experimental-strip-types dev/mock-oidc-server.ts",
     "dev-ui": "npm -w ui run dev",
     "dev-zellij": "dotenv -- zellij --layout .zellij.kdl",
+    "stop-dev-deps": "docker compose --profile dev stop",
     "build-types": "mkdir -p ui/src/components/vjsf && rm -f ui/src/components/vjsf/* && df-build-types . --vjsf-dir ui/src/components/vjsf",
     "prepare": "husky || true",
     "check-types": "tsc && npm -w ui run check-types",

--- a/tests/features/oidc-core-id.api.spec.ts
+++ b/tests/features/oidc-core-id.api.spec.ts
@@ -13,6 +13,7 @@ test.describe('global OIDC configuration in coreIdProvider mode', () => {
     await axiosBuilder().patch(mockOidcControlUrl2 + '/_test/userinfo', {
       sub: 'testoidc1',
       email: 'oidc1@test.com',
+      email_verified: true,
       given_name: 'Test',
       family_name: 'Oidc1'
     })
@@ -65,6 +66,7 @@ test.describe('global OIDC configuration in coreIdProvider mode', () => {
     await axiosBuilder().patch(mockOidcControlUrl2 + '/_test/userinfo', {
       sub: 'testoidc1',
       email: 'oidc1@test.com',
+      email_verified: true,
       given_name: 'Test',
       family_name: 'Oidc2'
     })

--- a/tests/features/oidc-ldap.inproc.spec.ts
+++ b/tests/features/oidc-ldap.inproc.spec.ts
@@ -3,7 +3,7 @@ import { test } from '@playwright/test'
 import { clean, startApiServer, stopApiServer, loginWithOIDC } from '../support/in-process-server.ts'
 import { OAuth2Server } from 'oauth2-mock-server'
 
-const oidcUserInfo1 = { sub: 'testoidc1', email: 'oidc1@test.com' }
+const oidcUserInfo1 = { sub: 'testoidc1', email: 'oidc1@test.com', email_verified: true }
 
 const startOAuthServer = async (port: number, oidcUserInfo: any) => {
   const oauthServer = new OAuth2Server()

--- a/tests/features/oidc.api.spec.ts
+++ b/tests/features/oidc.api.spec.ts
@@ -6,8 +6,8 @@ import { axiosBuilder } from '@data-fair/lib-node/axios.js'
 const mockOidcPort1 = parseInt(process.env.MOCK_OIDC_PORT1 || '8998')
 const mockOidcPort2 = parseInt(process.env.MOCK_OIDC_PORT2 || '8999')
 
-const oidcUserInfo1 = { sub: 'testoidc1', email: 'oidc1@test.com', given_name: 'OIDC', family_name: 'Test', role: 'contrib' }
-const oidcUserInfo2 = { sub: 'testoidc2', email: 'oidc2@test.com', given_name: 'OIDC', family_name: 'Test', role: 'contrib' }
+const oidcUserInfo1 = { sub: 'testoidc1', email: 'oidc1@test.com', email_verified: true, given_name: 'OIDC', family_name: 'Test', role: 'contrib' }
+const oidcUserInfo2 = { sub: 'testoidc2', email: 'oidc2@test.com', email_verified: true, given_name: 'OIDC', family_name: 'Test', role: 'contrib' }
 
 test.describe('global OIDC configuration', () => {
   test.beforeEach(async () => {

--- a/ui/dts/auto-imports.d.ts
+++ b/ui/dts/auto-imports.d.ts
@@ -184,18 +184,6 @@ declare module 'vue' {
     readonly customRef: UnwrapRef<typeof import('vue')['customRef']>
     readonly defineAsyncComponent: UnwrapRef<typeof import('vue')['defineAsyncComponent']>
     readonly defineComponent: UnwrapRef<typeof import('vue')['defineComponent']>
-    readonly dfDateMatchFilter: UnwrapRef<typeof import('@data-fair/lib-vuetify/date-match-filter.vue')['default']>
-    readonly dfDateRangePicker: UnwrapRef<typeof import('@data-fair/lib-vuetify/date-range-picker.vue')['default']>
-    readonly dfLangSwitcher: UnwrapRef<typeof import('@data-fair/lib-vuetify/lang-switcher.vue')['default']>
-    readonly dfNavigationRight: UnwrapRef<typeof import('@data-fair/lib-vuetify/navigation-right.vue')['default']>
-    readonly dfOwnerAvatar: UnwrapRef<typeof import('@data-fair/lib-vuetify/owner-avatar.vue')['default']>
-    readonly dfOwnerPick: UnwrapRef<typeof import('@data-fair/lib-vuetify/owner-pick.vue')['default']>
-    readonly dfPersonalMenu: UnwrapRef<typeof import('@data-fair/lib-vuetify/personal-menu.vue')['default']>
-    readonly dfThemeSwitcher: UnwrapRef<typeof import('@data-fair/lib-vuetify/theme-switcher.vue')['default']>
-    readonly dfTutorialAlert: UnwrapRef<typeof import('@data-fair/lib-vuetify/tutorial-alert.vue')['default']>
-    readonly dfUiNotif: UnwrapRef<typeof import('@data-fair/lib-vuetify/ui-notif.vue')['default']>
-    readonly dfUiNotifAlert: UnwrapRef<typeof import('@data-fair/lib-vuetify/ui-notif-alert.vue')['default']>
-    readonly dfUserAvatar: UnwrapRef<typeof import('@data-fair/lib-vuetify/ui-user-avatar.vue')['default']>
     readonly effectScope: UnwrapRef<typeof import('vue')['effectScope']>
     readonly formatBytes: UnwrapRef<typeof import('@data-fair/lib-vue/format/bytes.js')['formatBytes']>
     readonly getActiveHead: UnwrapRef<typeof import('@unhead/vue')['getActiveHead']>


### PR DESCRIPTION
  Harden the boundary between SSO-asserted identity and the privileges SD                                                                                         
  grants on top of it. Three intertwined gaps, one pass:
                                                                                                                                                                  
  - **Email verification is now fail-closed on every SSO provider.**                                                                                              
    OIDC requires `email_verified === true` (tightened from `!== false`),                                                                                         
    Google requires `verified_email === true`, GitHub requires a                                                                                                  
    `primary && verified` address, Facebook is refused outright (no flag                                                                                          
    exposed). A per-provider `ignoreEmailVerified` opt-out remains on OIDC                                                                                        
    for deployments that need it — gated behind superadmin-level config.                                                                                          
  - **Admin status is confined to main-site user records.** `cleanUser`                                                                                           
    (Mongo / file / LDAP) now gates `isAdmin` on `!user.host`. A record                                                                                           
    bound to a secondary site can never inherit admin rights even if the                                                                                          
    email matches `config.admins` — neutralizes cross-site admin takeover                                                                                         
    via a compromised/misconfigured site-level SSO.                                                                                                               
  - **SSO cannot produce a superadmin session by default.**                                                                                                       
    `authProviderLoginCallback` refuses a main-site SSO login resolving                                                                                           
    to an admin unless the provider is flagged `allowSuperadmin: true`.                                                                                           
    `adminMode=1` is explicitly refused on any non-main-site session                                                                                              
    (password and SSO paths), as defense in depth over the `!host` guard.                                                                                         
  - **Change-host tokens are bound to their target `(host, path)`.** The                                                                                          
    `/users/:id/host` endpoint now reads the target from the decoded                                                                                              
    token rather than the request body, and refuses admins listed in                                                                                              
    `config.admins` to prevent phishing-driven superadmin lockout. 