### PR TITLE
chore: API hardening — 5 quick wins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test-results
 ui/src/components/vjsf
 .env
 .playwright-mcp
+docs/local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ The full test suite is run by a git hook on push. When iterating on changes, alw
 
 Set `IGNORE_ASSERT_REQ_INTERNAL=true` to bypass internal secret validation in tests.
 
+`/api/test-env` is gated behind `ENABLE_TEST_API=1` (in addition to `NODE_ENV ∈ {development, test}`). The `npm run dev` script sets it; tests using `tests/support/in-process-server.ts` set it too. Never set it in production — the server refuses to start if `NODE_ENV=production` and `ENABLE_TEST_API=1`.
+
 ### Linting & Type Checking
 
 ```bash

--- a/api/config/test.cjs
+++ b/api/config/test.cjs
@@ -71,6 +71,11 @@ module.exports = {
     attempts: 100,
     duration: 60
   },
+  anonymousAction: {
+    // short notBefore keeps tests fast — in prod this is 8s to trip bots
+    expiresIn: '1d',
+    notBefore: '0s'
+  },
   perOrgStorageTypes: ['ldap'],
   mails: {
     from: 'no-reply@test.com',

--- a/api/doc/users/post-req/schema.js
+++ b/api/doc/users/post-req/schema.js
@@ -9,6 +9,8 @@ const body = jsonSchema(UserSchema)
   .schema
 
 body.properties.password = { type: 'string' }
+// anonymous-action token required for unauthenticated callers (bot / email-amplifier gate)
+body.properties.token = { type: 'string' }
 
 export default {
   $id: 'https://github.com/data-fair/simple-directory/users/post-req',

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "mkdir -p ../dev/logs && NODE_ENV=development DEBUG=upgrade* node --watch --experimental-strip-types index.ts 2>&1 | tee ../dev/logs/dev-api.log"
+    "dev": "mkdir -p ../dev/logs && NODE_ENV=development ENABLE_TEST_API=1 DEBUG=upgrade* node --watch --experimental-strip-types index.ts 2>&1 | tee ../dev/logs/dev-api.log"
   },
   "imports": {
     "#config": "./src/config.ts",
@@ -59,6 +59,6 @@
     "simple-oauth2": "^5.1.0",
     "slugify": "^1.6.8",
     "tinycolor2": "^1.6.0",
-    "useragent": "^2.3.0"
+    "ua-parser-js": "^2.0.9"
   }
 }

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -88,7 +88,19 @@ app.use('/api/accounts', accounts)
 app.use('/api/sites', sites)
 app.use('/api/password-lists', passwordLists)
 
-if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
+// /api/test-env exposes unauthenticated super-admin primitives (mutate config, seed users, rotate keys, wipe DB).
+// It is gated behind both NODE_ENV ∈ {development,test} *and* an explicit ENABLE_TEST_API=1 opt-in.
+// Refuses to start at all if NODE_ENV=production, regardless of the opt-in.
+if (process.env.ENABLE_TEST_API === '1') {
+  if (process.env.NODE_ENV === 'production') {
+    console.error('FATAL: ENABLE_TEST_API=1 is forbidden when NODE_ENV=production — refusing to start.')
+    process.exit(1)
+  }
+  if (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test') {
+    console.error(`FATAL: ENABLE_TEST_API=1 requires NODE_ENV ∈ {development, test}, got "${process.env.NODE_ENV}" — refusing to start.`)
+    process.exit(1)
+  }
+  console.warn('⚠️  /api/test-env IS MOUNTED — unauthenticated admin surface. ENABLE_TEST_API=1 + NODE_ENV=' + process.env.NODE_ENV + '. DO NOT expose this process to untrusted networks.')
   const testEnv = (await import('./test-env.ts')).default
   app.use('/api/test-env', testEnv)
 }

--- a/api/src/auth/router.ts
+++ b/api/src/auth/router.ts
@@ -5,7 +5,7 @@ import { reqUser, reqIp, reqSiteUrl, reqUserAuthenticated, session, httpError, r
 import bodyParser from 'body-parser'
 import Cookies from 'cookies'
 import Debug from 'debug'
-import { sendMailI18n, postUserIdentityWebhook, getOidcProviderId, oauthGlobalProviders, initOidcProvider, getOAuthProviderById, getOAuthProviderByState, reqSite, getSiteByUrl, check2FASession, is2FAValid, cookie2FAName, getTokenPayload, prepareCallbackUrl, signToken, decodeToken, setSessionCookies, getDefaultUserOrg, logout, keepalive, logoutOAuthToken, readOAuthToken, writeOAuthToken, authProviderMemberInfo, patchCoreAuthUser, saml2ServiceProvider, initServerSession, getSamlProviderById, authProviderLoginCallback, getDefaultLoginRedirect } from '#services'
+import { sendMailI18n, postUserIdentityWebhook, getOidcProviderId, oauthGlobalProviders, initOidcProvider, getOAuthProviderById, getOAuthProviderByState, reqSite, getSiteByUrl, getRedirectSite, check2FASession, is2FAValid, cookie2FAName, getTokenPayload, prepareCallbackUrl, signToken, decodeToken, setSessionCookies, getDefaultUserOrg, logout, keepalive, logoutOAuthToken, readOAuthToken, writeOAuthToken, authProviderMemberInfo, patchCoreAuthUser, saml2ServiceProvider, initServerSession, getSamlProviderById, authProviderLoginCallback, getDefaultLoginRedirect } from '#services'
 import type { SdStorage } from '../storages/interface.ts'
 import type { ActionPayload, ServerSession, User } from '#types'
 import eventsLog, { type EventLogContext } from '@data-fair/lib-express/events-log.js'
@@ -59,11 +59,8 @@ router.post('/password', rejectCoreIdUser, async (req, res, next) => {
   const returnError = async (error: string, errorCode: number) => {
     // prevent attacker from analyzing response time
     await new Promise(resolve => setTimeout(resolve, Math.round(Math.random() * 1000)))
-    const referer = req.headers.referer || req.headers.referrer
-    if (req.is('application/x-www-form-urlencoded') && typeof referer === 'string') {
-      const refererUrl = new URL(referer)
-      refererUrl.searchParams.set('error', error)
-      res.redirect(refererUrl.href)
+    if (req.is('application/x-www-form-urlencoded')) {
+      res.redirect(`${reqSiteUrl(req)}/simple-directory/login?error=${encodeURIComponent(error)}`)
     } else {
       res.status(errorCode).send(reqI18n(req).messages.errors[error] || error)
     }
@@ -380,7 +377,13 @@ router.get('/token_callback', async (req, res, next) => {
     return redirectError('badCredentials')
   }
 
-  const reboundRedirect = getDefaultLoginRedirect(reqSiteUrl(req), query.redirect)
+  let reboundRedirect = getDefaultLoginRedirect(reqSiteUrl(req), query.redirect)
+  try {
+    await getRedirectSite(req, reboundRedirect)
+  } catch (err) {
+    eventsLog.alert('sd.auth.callback.redirect-rejected', `a token_callback redirect to ${reboundRedirect} was rejected as off-site`, logContext)
+    reboundRedirect = getDefaultLoginRedirect(reqSiteUrl(req))
+  }
 
   const site = await reqSite(req)
   const payload = getTokenPayload(user, site)
@@ -679,7 +682,6 @@ const oauthLogin: RequestHandler = async (req, res, next) => {
     _id: randomUUID(),
     createdAt: new Date(),
     providerState: provider.state,
-    loginReferer: req.headers.referer,
     redirect: getDefaultLoginRedirect(reqSiteUrl(req), req.query.redirect as string).replace('?id_token=', ''),
     org: req.query.org as string,
     dep: req.query.dep as string,
@@ -707,17 +709,11 @@ const oauthCallback: RequestHandler = async (req, res, next) => {
   }
   const relayState = await mongo.oauthRelayStates.findOne({ _id: req.query.state as string })
   if (!relayState) return res.status(404).send('Unknown relay state')
-  const { providerState, loginReferer, redirect, org, dep, invitToken, adminMode } = relayState
+  const { providerState, redirect, org, dep, invitToken, adminMode } = relayState
   const returnError = (error: string, errorCode: number) => {
     eventsLog.info('sd.auth.oauth.fail', `a user failed to authenticate with oauth due to ${error}`, logContext)
     debugOAuth('login return error', error, errorCode)
-    if (loginReferer) {
-      const refererUrl = new URL(loginReferer)
-      refererUrl.searchParams.set('error', error)
-      res.redirect(refererUrl.href)
-    } else {
-      res.status(errorCode).send(reqI18n(req).messages.errors[error] || error)
-    }
+    res.redirect(`${reqSiteUrl(req)}/simple-directory/login?error=${encodeURIComponent(error)}`)
   }
 
   const provider = await getOAuthProviderByState(req, providerState)
@@ -792,7 +788,6 @@ router.get('/saml2/:providerId/login', async (req, res) => {
   const relayState: Saml2RelayState = {
     _id: randomUUID(),
     createdAt: new Date(),
-    loginReferer: req.headers.referer,
     redirect: getDefaultLoginRedirect(reqSiteUrl(req), req.query.redirect as string).replace('?id_token=', ''),
     org: req.query.org as string,
     dep: req.query.dep as string,
@@ -823,7 +818,7 @@ router.post('/saml2-assert', async (req, res) => {
   if (!req.body.RelayState) throw httpError(400, 'missing body.RelayState')
   const relayState = await mongo.saml2RelayStates.findOne({ _id: req.body.RelayState })
   if (!relayState) return res.status(404).send('unknown relay state')
-  const { loginReferer, redirect, org, dep, invitToken, adminMode, providerId } = relayState
+  const { redirect, org, dep, invitToken, adminMode, providerId } = relayState
 
   const provider = await getSamlProviderById(req, providerId)
   if (!provider) return res.status(404).send('unknown saml2 provider ' + providerId)
@@ -837,13 +832,7 @@ router.post('/saml2-assert', async (req, res) => {
   const returnError = (error: string, errorCode: number) => {
     eventsLog.info('sd.auth.saml.fail', `a user failed to authenticate with saml due to ${error}`, logContext)
     debugSAML('login return error', error, errorCode)
-    if (loginReferer) {
-      const refererUrl = new URL(loginReferer)
-      refererUrl.searchParams.set('error', error)
-      res.redirect(refererUrl.href)
-    } else {
-      res.status(errorCode).send(reqI18n(req).messages.errors[error] || error)
-    }
+    res.redirect(`${reqSiteUrl(req)}/simple-directory/login?error=${encodeURIComponent(error)}`)
   }
 
   const userAttrs = getSamlUserAttrs(samlResponse.extract.attributes, logContext)

--- a/api/src/auth/service.ts
+++ b/api/src/auth/service.ts
@@ -1,4 +1,4 @@
-import useragent from 'useragent'
+import { UAParser } from 'ua-parser-js'
 import debugModule from 'debug'
 import config from '#config'
 import type { Request } from 'express'
@@ -299,9 +299,17 @@ export const patchCoreAuthUser = async (provider: AuthProviderCore, user: User, 
   return await storages.globalStorage.patchUser(user.id, patch)
 }
 
+const formatDeviceName = (agentHeader: string) => {
+  const { browser, os } = UAParser(agentHeader)
+  const browserPart = [browser.name, browser.version].filter(Boolean).join(' ')
+  const osPart = [os.name, os.version].filter(Boolean).join(' ')
+  const combined = [browserPart, osPart].filter(Boolean).join(' / ')
+  return combined || 'appareil inconnu'
+}
+
 export const initServerSession = (req: Request): ServerSession => {
   const agentHeader = req.get('user-agent')
-  const deviceName = agentHeader ? useragent.parse(agentHeader).toString() : 'appareil inconnu'
+  const deviceName = agentHeader ? formatDeviceName(agentHeader) : 'appareil inconnu'
   return {
     id: nanoid(),
     createdAt: new Date().toISOString(),

--- a/api/src/oauth/service.ts
+++ b/api/src/oauth/service.ts
@@ -57,7 +57,6 @@ export type OAuthRelayState = {
   _id: string,
   createdAt: Date,
   providerState: string,
-  loginReferer?: string,
   redirect: string,
   org?: string,
   dep?: string,

--- a/api/src/saml2/service.ts
+++ b/api/src/saml2/service.ts
@@ -28,7 +28,6 @@ export type Saml2RelayState = {
   _id: string,
   createdAt: Date,
   providerId: string,
-  loginReferer?: string,
   redirect: string,
   org?: string,
   dep?: string,

--- a/api/src/users/router.ts
+++ b/api/src/users/router.ts
@@ -1,7 +1,7 @@
 import { type Organization, type UserWritable } from '#types'
 import { Router, type RequestHandler } from 'express'
 import config from '#config'
-import { reqSessionAuthenticated, mongoPagination, mongoSort, session, reqSiteUrl, reqSession, httpError } from '@data-fair/lib-express'
+import { reqSessionAuthenticated, mongoPagination, mongoSort, session, reqSiteUrl, reqSession, reqUser, httpError } from '@data-fair/lib-express'
 import eventsLog, { type EventLogContext } from '@data-fair/lib-express/events-log.js'
 import { nanoid } from 'nanoid'
 import eventsQueue from '#events-queue'
@@ -73,6 +73,26 @@ router.post('', async (req, res, next) => {
 
   const { body, query } = (await import('#doc/users/post-req/index.ts')).returnValid(req, { name: 'req' })
 
+  // anonymous-action token gate: anonymous callers must hold a /auth/anonymous-action token
+  // (notBefore delay traps instant-POST bots; per-IP limiter on the issuing endpoint caps abuse rate).
+  // Authenticated callers are exempt — they're already rate-gated elsewhere and have an audit trail.
+  if (!reqUser(req)) {
+    if (!body.token) {
+      eventsLog.warn('sd.user.create.missing-token', 'anonymous POST /api/users without anonymous-action token', logContext)
+      return res.status(401).send(reqI18n(req).messages.errors.missingToken)
+    }
+    try {
+      await session.verifyToken(body.token)
+    } catch (err: any) {
+      if (err.name === 'NotBeforeError') {
+        eventsLog.alert('sd.user.create.bot-suspected', 'POST /api/users with premature anonymous-action token', logContext)
+        return res.status(429).send(reqI18n(req).messages.errors.rateLimitAuth)
+      }
+      eventsLog.warn('sd.user.create.invalid-token', `POST /api/users with invalid anonymous-action token: ${err.name}`, logContext)
+      return res.status(401).send(reqI18n(req).messages.errors.invalidToken)
+    }
+  }
+
   const storage = storages.globalStorage
 
   // used to create a user and accept a member invitation at the same time
@@ -132,7 +152,13 @@ router.post('', async (req, res, next) => {
   const user = await storages.globalStorage.getUserByEmail(body.email, await reqSite(req))
 
   // email is already taken, send a conflict email
-  const link = getDefaultLoginRedirect(reqSiteUrl(req), query.redirect)
+  let link = getDefaultLoginRedirect(reqSiteUrl(req), query.redirect)
+  try {
+    await getRedirectSite(req, link)
+  } catch (err) {
+    eventsLog.alert('sd.user.create.redirect-rejected', `a user creation redirect to ${link} was rejected as off-site`, logContext)
+    link = getDefaultLoginRedirect(reqSiteUrl(req))
+  }
   if (user && user.emailConfirmed !== false) {
     const linkUrl = new URL(link)
     await sendMailI18n('conflict', reqI18n(req).messages, body.email, { host: linkUrl.host, origin: linkUrl.origin })

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "@types/serialize-javascript": "^5.0.4",
         "@types/simple-oauth2": "^5.0.8",
         "@types/tinycolor2": "^1.4.6",
-        "@types/useragent": "^2.3.4",
         "commitlint": "^19.8.1",
         "dotenv": "^17.3.1",
         "dotenv-cli": "^11.0.0",
@@ -105,7 +104,7 @@
         "simple-oauth2": "^5.1.0",
         "slugify": "^1.6.8",
         "tinycolor2": "^1.6.0",
-        "useragent": "^2.3.0"
+        "ua-parser-js": "^2.0.9"
       }
     },
     "node_modules/@antfu/utils": {
@@ -2960,11 +2959,6 @@
       "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==",
       "license": "MIT"
     },
-    "node_modules/@types/useragent": {
-      "version": "2.3.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/vue-cropperjs": {
       "version": "4.1.6",
       "license": "MIT",
@@ -4923,6 +4917,26 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -7169,6 +7183,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/is-string": {
       "version": "1.0.7",
       "dev": true,
@@ -9308,13 +9342,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/otplib": {
       "version": "12.0.1",
       "license": "MIT",
@@ -9786,10 +9813,6 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "license": "MIT"
-    },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "license": "ISC"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -11304,16 +11327,6 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/tmp": {
-      "version": "0.0.33",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "license": "MIT",
@@ -11557,6 +11570,57 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.9.tgz",
+      "integrity": "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ufo": {
@@ -11979,26 +12043,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/useragent": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "4.1.x",
-        "tmp": "0.0.x"
-      }
-    },
-    "node_modules/useragent/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "license": "ISC",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/useragent/node_modules/yallist": {
-      "version": "2.1.2",
-      "license": "ISC"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "@types/serialize-javascript": "^5.0.4",
     "@types/simple-oauth2": "^5.0.8",
     "@types/tinycolor2": "^1.4.6",
-    "@types/useragent": "^2.3.4",
     "commitlint": "^19.8.1",
     "dotenv": "^17.3.1",
     "dotenv-cli": "^11.0.0",

--- a/tests/features/invitations.api.spec.ts
+++ b/tests/features/invitations.api.spec.ts
@@ -45,7 +45,8 @@ test.describe('invitations', () => {
     assert.equal(members.length, 1)
 
     // create user and accept invitation
-    await anonymousAx.post('/api/users', { email: 'test-invit2@test.com', password: 'Test1234' }, { params: { invit_token: invitToken } })
+    const token2 = (await anonymousAx.get('/api/auth/anonymous-action')).data
+    await anonymousAx.post('/api/users', { email: 'test-invit2@test.com', password: 'Test1234', token: token2 }, { params: { invit_token: invitToken } })
     members = (await ax.get(`/api/organizations/${org.id}/members`)).data.results
     assert.equal(members.length, 2)
     const newMember = members.find((m: any) => m.email === 'test-invit2@test.com')
@@ -171,7 +172,8 @@ test.describe('invitations', () => {
     assert.equal(newMember.emailConfirmed, false)
 
     // finalize user creation and invitation
-    await anonymousAx.post('/api/users', { email: 'test-invit6@test.com', password: 'Test1234' }, { params: { invit_token: invitToken } })
+    const token6 = (await anonymousAx.get('/api/auth/anonymous-action')).data
+    await anonymousAx.post('/api/users', { email: 'test-invit6@test.com', password: 'Test1234', token: token6 }, { params: { invit_token: invitToken } })
     members = (await ax.get(`/api/organizations/${org.id}/members`)).data.results
     assert.equal(members.length, 2)
     newMember = members.find((m: any) => m.email === 'test-invit6@test.com')
@@ -233,7 +235,8 @@ test.describe('invitations', () => {
     const invitToken = new URL(redirect ?? '').searchParams.get('invit_token')
 
     // create user and accept invitation
-    await anonymousAx.post('/api/users', { email: 'test-invit10@test.com', password: 'Test1234' }, { params: { invit_token: invitToken } })
+    const token10 = (await anonymousAx.get('/api/auth/anonymous-action')).data
+    await anonymousAx.post('/api/users', { email: 'test-invit10@test.com', password: 'Test1234', token: token10 }, { params: { invit_token: invitToken } })
     members = (await ax.get(`/api/organizations/${org.id}/members`)).data.results
     assert.equal(members.length, 2)
     const newMember = members.find((m: any) => m.email === 'test-invit10@test.com')
@@ -301,7 +304,8 @@ test.describe('invitations', () => {
     const invitToken = new URL(redirect ?? '').searchParams.get('invit_token')
 
     // create user and accept invitation
-    await anonymousAx.post('/api/users', { email: 'test-invit-multi-dep2@test.com', password: 'Test1234' }, { params: { invit_token: invitToken } })
+    const tokenMd2 = (await anonymousAx.get('/api/auth/anonymous-action')).data
+    await anonymousAx.post('/api/users', { email: 'test-invit-multi-dep2@test.com', password: 'Test1234', token: tokenMd2 }, { params: { invit_token: invitToken } })
     members = (await ax.get(`/api/organizations/${org.id}/members`)).data.results
     console.log('members', members)
     assert.equal(members.length, 3)
@@ -357,7 +361,8 @@ test.describe('invitations', () => {
     const invitToken = new URL(mail.link).searchParams.get('invit_token')
 
     // finalize user creation and invitation
-    await anonymousAx.post(`http://127.0.0.1:${process.env.NGINX_PORT2}/simple-directory/api/users`, { email: 'test-invit11@test.com', password: 'Test1234' }, { params: { invit_token: invitToken } })
+    const token11 = (await anonymousAx.get(`http://127.0.0.1:${process.env.NGINX_PORT2}/simple-directory/api/auth/anonymous-action`)).data
+    await anonymousAx.post(`http://127.0.0.1:${process.env.NGINX_PORT2}/simple-directory/api/users`, { email: 'test-invit11@test.com', password: 'Test1234', token: token11 }, { params: { invit_token: invitToken } })
 
     // after accepting the user is a member
     const members = (await ax.get(`/api/organizations/${org.id}/members`)).data.results
@@ -442,7 +447,8 @@ test.describe('invitations', () => {
     const invitToken = new URL(mail.link).searchParams.get('invit_token')
 
     // finalize user creation and invitation
-    await anonymousAx.post('/api/users', { email: 'test-invit14@test.com', password: 'Test1234' }, { params: { invit_token: invitToken } })
+    const token14 = (await anonymousAx.get('/api/auth/anonymous-action')).data
+    await anonymousAx.post('/api/users', { email: 'test-invit14@test.com', password: 'Test1234', token: token14 }, { params: { invit_token: invitToken } })
 
     // after accepting the user is a member
     const members = (await ax.get(`/api/organizations/${org.id}/members`)).data.results

--- a/tests/features/users.api.spec.ts
+++ b/tests/features/users.api.spec.ts
@@ -12,9 +12,11 @@ test.describe('users api', () => {
     const config = await getServerConfig()
     const ax = await axios()
 
+    const token = (await ax.get('/api/auth/anonymous-action')).data
+
     // create user via API and wait for confirmation mail via SSE
     const mail = await waitForMail(
-      () => ax.post('/api/users', { email: 'user@test.com', password: 'Test1234' }),
+      () => ax.post('/api/users', { email: 'user@test.com', password: 'Test1234', token }),
       (m) => m.to === 'user@test.com' && m.link?.includes('token_callback')
     )
 

--- a/tests/state-setup.ts
+++ b/tests/state-setup.ts
@@ -14,6 +14,10 @@ setup('Stateful tests setup', async () => {
 If you are an agent do not try to start it. Instead check for a startup failure at the end of dev/logs/dev-api.log and report this problem to your user.`
   )
 
+  // drop the anonymous-action notBefore to 0 so tests don't wait 8s per user creation
+  // (the 8s delay is a bot trap; programmatic tests are not bots)
+  await ax.patch(`${devApiUrl}/api/test-env/config`, { anonymousAction: { expiresIn: '1d', notBefore: '0s' } })
+
   // Check that the mock OIDC servers are up
   const mockOidcPort1 = parseInt(process.env.MOCK_OIDC_PORT1 || '8998')
   const mockOidcPort2 = parseInt(process.env.MOCK_OIDC_PORT2 || '8999')

--- a/tests/support/axios.ts
+++ b/tests/support/axios.ts
@@ -107,8 +107,10 @@ export const createUser = async (email: string, adminMode = false, password = 'T
   const createAxiosOpts = { baseURL: baseUrl }
   const anonymAx = await axios(createAxiosOpts)
 
+  const token = (await anonymAx.get('/api/auth/anonymous-action')).data
+
   const mail = await waitForMail(
-    () => anonymAx.post('/api/users', { email, password }),
+    () => anonymAx.post('/api/users', { email, password, token }),
     (m) => m.to === email && m.link?.includes('token_callback')
   )
 

--- a/tests/support/e2e-fixtures.ts
+++ b/tests/support/e2e-fixtures.ts
@@ -34,10 +34,12 @@ export const test = base.extend<E2eFixtures>({
       const adminMode = opts?.adminMode || false
       const anonymAx = await axios()
 
+      const token = (await anonymAx.get('/api/auth/anonymous-action')).data
+
       // Create user and wait for confirmation email
       const mail = await waitForMail(
         async () => {
-          await anonymAx.post('/api/users', { email, password })
+          await anonymAx.post('/api/users', { email, password, token })
         },
         (m) => m.to === email && m.link?.includes('token_callback')
       )

--- a/tests/support/in-process-server.ts
+++ b/tests/support/in-process-server.ts
@@ -3,6 +3,7 @@
 
 // Must be set before config module is loaded
 process.env.NODE_ENV = 'test'
+process.env.ENABLE_TEST_API = '1'
 process.env.NODE_CONFIG_DIR = process.env.NODE_CONFIG_DIR || './api/config/'
 
 import { strict as assert } from 'node:assert'

--- a/ui/src/pages/login.vue
+++ b/ui/src/pages/login.vue
@@ -1005,11 +1005,15 @@ function preLogin () {
   }
 }
 
+// fetched at mount so the notBefore (8s) is almost certainly elapsed by the time the user submits
+const createUserToken = useFetch<string>($apiPath + '/auth/anonymous-action')
+
 const createUserForm = ref<InstanceType<typeof VForm>>()
 const createUser = useAsyncAction(async () => {
   await createUserForm.value?.validate()
   if (!createUserForm.value?.isValid) return
-  const body: PostUserReq['body'] = { email: email.value, ...newUser.value }
+  if (!createUserToken.data.value) return
+  const body: PostUserReq['body'] = { email: email.value, ...newUser.value, token: createUserToken.data.value }
   const link = await $fetch('users', {
     method: 'POST',
     body,


### PR DESCRIPTION
Five low-risk hardening changes, bundled into one commit. No data migrations, no protocol changes, no public-API breakage.

- make extra sure test-env router is never run in production
- drop referer based redirects
- redirect validation
- anonymous action token on user creation
- replace useragent module with ua-parser-js