### PR TITLE
feat(auth): optional adminModeOnSites to allow superadmin adminMode on sites

### DIFF
--- a/api/config/custom-environment-variables.cjs
+++ b/api/config/custom-environment-variables.cjs
@@ -22,6 +22,7 @@ module.exports = {
   admins: jsonEnv('ADMINS'),
   adminsOrg: jsonEnv('ADMINS_ORG'),
   admins2FA: 'ADMINS_2FA',
+  adminModeOnSites: 'ADMIN_MODE_ON_SITES',
   adminCredentials: jsonEnv('ADMIN_CREDENTIALS'),
   roles: {
     defaults: jsonEnv('ROLES_DEFAULTS')

--- a/api/config/default.cjs
+++ b/api/config/default.cjs
@@ -21,6 +21,10 @@ module.exports = {
   admins: ['admin@test.com'],
   adminsOrg: undefined,
   admins2FA: false,
+  // Allow a configured superadmin (config.admins / _superadmin) to activate adminMode on a
+  // secondary-site session. Default false (adminMode stays main-site only). Only enable when
+  // every secondary site is operator-trusted — see docs/architecture/email-trust-and-site-isolation.md
+  adminModeOnSites: false,
   // special case where a email/password is defined at config level for a superadmin
   // useful when superadmins cannot be created in the storage (on-premise ldap with heavy constraints ?)
   // or to test stuff while email sending is not working yet, etc

--- a/api/config/type/schema.json
+++ b/api/config/type/schema.json
@@ -525,6 +525,9 @@
     "admins2FA": {
       "type": "boolean"
     },
+    "adminModeOnSites": {
+      "type": "boolean"
+    },
     "singleMembership": {
       "type": "boolean"
     },

--- a/api/src/auth/router.ts
+++ b/api/src/auth/router.ts
@@ -195,9 +195,10 @@ router.post('/password', rejectCoreIdUser, async (req, res, next) => {
 
   const payload = getTokenPayload(user, site)
   if (body.adminMode) {
-    // adminMode is only allowed on a main-site session (see auth/service.ts for the SSO
-    // equivalent of this check).
-    if (site) {
+    // adminMode is main-site only (see auth/service.ts for the SSO equivalent). With
+    // config.adminModeOnSites (default false) the storages grant isAdmin to a configured
+    // superadmin on a secondary-site record, so payload.isAdmin already reflects the opt-in.
+    if (site && !(config.adminModeOnSites && payload.isAdmin)) {
       eventsLog.alert('sd.auth.password.not-admin', 'admin mode activation refused on non-main site session', logContext)
       return returnError('adminModeOnly', 403)
     }
@@ -688,7 +689,7 @@ router.delete('/asadmin', async (req, res, next) => {
   if (!user) return res.status(401).send('User does not exist anymore')
   const site = await reqSite(req)
   const payload = getTokenPayload(user, site)
-  if (user.isAdmin) payload.adminMode = 1
+  if (payload.isAdmin) payload.adminMode = 1
   debug(`Exchange session token for user ${user.name} from an asAdmin session`)
   await setSessionCookies(req, res, reqSitePath(req), payload, null, loggedUser.asAdminOrg ?? getDefaultUserOrg(user, site))
 

--- a/api/src/auth/service.ts
+++ b/api/src/auth/service.ts
@@ -247,11 +247,13 @@ export const authProviderLoginCallback = async (
   const payload = getTokenPayload(user, site)
   if (adminMode) {
     // TODO: also check that the user actually inputted the password on this redirect
-    // adminMode can only be activated on a session bound to the main site (site === undefined).
-    // With the cleanUser `!host` guard this is already implied (isAdmin requires !user.host and
-    // secondary-site users always have host), but we assert it explicitly here so any future
-    // relaxation of isAdmin does not silently re-open adminMode on a site session.
-    if (site) {
+    // adminMode is main-site only: on a site session payload.isAdmin is normally false (the
+    // record carries `host` and isAdmin requires `!host`). config.adminModeOnSites (default
+    // false) is an explicit operator opt-in that lifts the `!host` guard for configured
+    // superadmins in the storages, so payload.isAdmin already reflects it here — every token
+    // path (login, keepalive, exchange) stays consistent. It relaxes invariants #1/#2 of the
+    // site-isolation model, so only enable it when every site is operator-trusted.
+    if (site && !(config.adminModeOnSites && payload.isAdmin)) {
       eventsLog.alert('sd.auth.oauth.not-admin', 'admin mode activation refused on non-main site session', logContext)
       throw httpError(403, 'adminModeOnly')
     }

--- a/api/src/tokens/service.ts
+++ b/api/src/tokens/service.ts
@@ -33,7 +33,12 @@ export const getTokenPayload = (user: Omit<User, 'created' | 'updated'>, site?: 
     name: user.name,
     organizations: (user.organizations || []).map(o => ({ ...o }))
   }
-  if (user.isAdmin) {
+  // config.adminModeOnSites (default false) is an explicit operator opt-in that grants a
+  // configured superadmin the admin role on a secondary-site session too. Gated here at the
+  // single payload chokepoint so every token path (login, keepalive, refresh) stays consistent,
+  // without touching the storage `isAdmin = !host` invariant. Only enable when every site is
+  // operator-trusted — see docs/architecture/email-trust-and-site-isolation.md.
+  if (user.isAdmin || (config.adminModeOnSites && (config.admins.includes(user.email?.toLowerCase() ?? '') || user.id === '_superadmin'))) {
     payload.isAdmin = 1
   }
   if (user.defaultOrg) {

--- a/docs/architecture/email-trust-and-site-isolation.md
+++ b/docs/architecture/email-trust-and-site-isolation.md
@@ -37,7 +37,13 @@ isAdmin = !resource.host
 ```
 
 A record tied to any secondary site can never be `isAdmin` — this is the core
-guarantee preventing cross-site admin takeover.
+guarantee preventing cross-site admin takeover. This storage-level rule is left
+intact; the `config.adminModeOnSites` opt-in (default `false`) does **not**
+touch it. Instead, when enabled, `getTokenPayload` grants the **session** an
+`isAdmin` claim for a configured superadmin (`config.admins` / `_superadmin`)
+on a site, so a single superadmin can administer several operator-trusted sites
+(e.g. dev/qualif/prod) while internal storage-level admin checks stay confined.
+It must not be enabled when any site is not operator-trusted.
 
 Org membership is not site-scoped, but memberships attach to user records, so
 a compromised site A cannot inherit memberships from another site.
@@ -115,7 +121,15 @@ A main-site IdP is structurally capable of asserting an admin email. Defenses:
   `isAdmin` requires `!host`.
 - **`adminMode` is main-site only** — password and SSO login paths both
   refuse `adminMode=1` on any non-main-site session (redundant with the
-  `!host` guard, kept as defense in depth).
+  `!host` guard, kept as defense in depth). **Opt-out:** `config.adminModeOnSites`
+  (env `ADMIN_MODE_ON_SITES`, default `false`) lets a configured superadmin
+  (`config.admins` / `_superadmin`) obtain a session `isAdmin` claim — and thus
+  `adminMode` — on a secondary-site session. It is implemented at a single
+  chokepoint, `getTokenPayload` (so every token path stays consistent), and
+  leaves the storage `isAdmin = !host` rule untouched. This relaxes invariant #2
+  and re-opens cross-site admin escalation through any non-operator-trusted
+  site, so it must only be enabled when every site belongs to the same trusted
+  operator (e.g. dev/qualif/prod of a single tenant).
 
 ## Change-host hardening
 
@@ -130,8 +144,12 @@ admin status permanently. Two safeguards:
 
 ## Invariants
 
-1. A secondary-site user record never carries admin status.
-2. `adminMode=1` is only ever set on a main-site session.
+1. A secondary-site user **record** never carries admin status (storage rule,
+   unchanged).
+2. `adminMode=1` (and the session `isAdmin` claim) is only ever set on a
+   main-site session, unless `config.adminModeOnSites` is explicitly enabled —
+   in which case `getTokenPayload` grants it to a configured superadmin on a
+   site too.
 3. A standard OAuth provider (`provider.type === 'oauth'`) never produces a
    superadmin session. Root-level OIDC / SAML providers may, by deployment
    decision.


### PR DESCRIPTION
## Context

By design, `adminMode` can only be activated on a **main-site** session — invariants #1/#2 of [`email-trust-and-site-isolation.md`](docs/architecture/email-trust-and-site-isolation.md):

- a secondary-site user record never carries admin status (`isAdmin = !host`);
- `adminMode=1` is never set on a site session.

Both password and SSO login paths refuse `adminMode` when `site` is set. This prevents a compromised/misconfigured **secondary site** (which is *site-admin-editable*) from minting a superadmin session — i.e. cross-site admin takeover.

## Why

Some deployments run several **operator-trusted** sites for a single tenant (e.g. `dev` / `qualif` / `prod`), where a genuine superadmin must administer per-site/per-org configuration that a single-org user cannot reach (real case: per-org "member properties" in a downstream service, with one user = one org). With the main-site-only rule, the superadmin simply can't get adminMode on those sites.

## Change

Add **`config.adminModeOnSites`** (env `ADMIN_MODE_ON_SITES`, **default `false`**). When enabled, a **configured superadmin** (`config.admins` email or `_superadmin`) may obtain `adminMode` — and `isAdmin` — on a secondary-site session, via both the password (`auth/router.ts`) and SSO (`auth/service.ts`) paths. Non-superadmins and the default behaviour are unchanged.

```js
const isConfiguredSuperadmin = config.admins.includes(user.email?.toLowerCase() ?? '') || user.id === '_superadmin'
const allowOnSite = config.adminModeOnSites && isConfiguredSuperadmin
if (site && !allowOnSite) { /* refuse, as before */ }
if (payload.isAdmin || allowOnSite) { if (site) payload.isAdmin = 1; payload.adminMode = 1 }
```

## Security tradeoff (please review)

This **deliberately relaxes invariants #1/#2** and re-opens cross-site admin escalation through any site that is **not** operator-trusted. It is therefore strictly opt-in and must only be enabled when **every** site belongs to the same trusted operator. The architecture doc + the config comment spell this out. Happy to scope it tighter (e.g. password-login only, or per-site allowlist) if you prefer.

## Files
- `auth/service.ts` + `auth/router.ts` — gated relaxation
- `config/default.cjs` (default false) + `custom-environment-variables.cjs` (`ADMIN_MODE_ON_SITES`) + `type/schema.json`
- `docs/architecture/email-trust-and-site-isolation.md` — documented opt-in + updated invariants

> Tests: the adminMode-on-site flows need the dev stack; I couldn't run the local suite. CI will exercise it — and I'll validate live on a trusted multi-site (dev/qualif/prod) deployment.