### PR TITLE
fix(theme): restore {FONT_FAMILY} substitution and font-name fallback

### DIFF
--- a/api/src/utils/theme.ts
+++ b/api/src/utils/theme.ts
@@ -10,15 +10,21 @@ export const getThemeCss = (theme: Theme, sitePath: string = '') => {
   if (theme.dark && theme.darkColors) css += getTextColorsCss(theme.darkColors, 'dark')
   if (theme.hc && theme.hcColors) css += getTextColorsCss(theme.hcColors, 'hc')
   if (theme.hcDark && theme.hcDarkColors) css += getTextColorsCss(theme.hcDarkColors, 'hc-dark')
+  // Resolve the font names first — defaulting to the legacy "BodyFontFamily" / "HeadingFontFamily"
+  // aliases when not explicitly configured — so they can be substituted into the {FONT_FAMILY}
+  // placeholder of the *Css @font-face rules. This keeps the @font-face family in sync with the
+  // CSS variables below and avoids emitting a literal `undefined` (or an unsubstituted
+  // {FONT_FAMILY}) when only the CSS, not the name, is configured.
+  const bodyFontFamily = theme?.bodyFontFamily || config.theme.bodyFontFamily || 'BodyFontFamily'
   const bodyFontFamilyCss = theme?.bodyFontFamilyCss ?? config.theme.bodyFontFamilyCss ?? ''
-  css += '\n' + microTemplate(bodyFontFamilyCss, { SITE_PATH: sitePath })
   const headingFontFamilyCss = theme?.headingFontFamilyCss ?? config.theme.headingFontFamilyCss
+  // Headings use a distinct "HeadingFontFamily" alias when a heading @font-face is provided (so
+  // it doesn't collide with the body @font-face name); otherwise they inherit the body font.
+  const headingFontFamily = theme?.headingFontFamily || config.theme.headingFontFamily || (headingFontFamilyCss ? 'HeadingFontFamily' : bodyFontFamily)
+  css += '\n' + microTemplate(bodyFontFamilyCss, { SITE_PATH: sitePath, FONT_FAMILY: bodyFontFamily })
   if (headingFontFamilyCss) {
-    css += '\n' + microTemplate(headingFontFamilyCss, { SITE_PATH: sitePath })
+    css += '\n' + microTemplate(headingFontFamilyCss, { SITE_PATH: sitePath, FONT_FAMILY: headingFontFamily })
   }
-
-  const bodyFontFamily = theme?.bodyFontFamily || config.theme.bodyFontFamily
-  const headingFontFamily = theme?.headingFontFamily || config.theme.headingFontFamily || bodyFontFamily
   css += `
 :root {
   --d-body-font-family: ${bodyFontFamily} !important;


### PR DESCRIPTION
## Problem

On master, a deployment that configures fonts via the CSS counterpart (`bodyFontFamilyCss` / `THEME_BODY_FONT_FAMILY_CSS`) using the `{FONT_FAMILY}` placeholder — as the MDC installer does — renders with a serif fallback. The served theme contains:

```css
--d-body-font-family: undefined !important;   /* and the @font-face keeps a literal {FONT_FAMILY} */
```

## Cause

The `getThemeCss` refactor dropped two behaviours 8.18.0 had:
1. `microTemplate(..., { FONT_FAMILY: 'BodyFontFamily' })` — so the `{FONT_FAMILY}` placeholder in the `@font-face` is no longer substituted (only `SITE_PATH` is);
2. the `|| 'BodyFontFamily'` fallback on the CSS variable — so when only the CSS (not the name) is configured, `bodyFontFamily` is `undefined` and the variable becomes literally `undefined`.

Independent of #125 (which addressed the config-merge / Nunito shadowing, not `theme.ts`).

## Fix

Resolve `bodyFontFamily` / `headingFontFamily` first (with the legacy `'BodyFontFamily'`/`'HeadingFontFamily'` alias fallback), then pass them as `FONT_FAMILY` to the `@font-face` `microTemplate` calls so the `@font-face` family matches the emitted CSS variables. Restores 8.18.0 behaviour; deployments that set explicit font names are unaffected.

Reproduced on a master deployment (served CSS = `--d-body-font-family: undefined`); validating on testbw.
