### PR TITLE
feat: expose theme preload links in /sites/_hashes

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -18,7 +18,7 @@
     "#i18n": "./i18n/index.ts"
   },
   "dependencies": {
-    "@data-fair/lib-express": "^1.19.0",
+    "@data-fair/lib-express": "^1.23.0",
     "@data-fair/lib-node": "^2.12.1",
     "@data-fair/lib-utils": "^1.10.1",
     "@sd/shared": "*",

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -35,6 +35,7 @@ const baseTheme = config.util.cloneDeep(defaultTheme)
 if (themeOverrides.bodyFontFamilyCss || themeOverrides.bodyFontFamily) {
   delete baseTheme.bodyFontFamily
   delete baseTheme.bodyFontFamilyCss
+  delete baseTheme.preloadLinks
 }
 if (themeOverrides.headingFontFamilyCss || themeOverrides.headingFontFamily) {
   delete baseTheme.headingFontFamily

--- a/api/src/sites/router.ts
+++ b/api/src/sites/router.ts
@@ -255,7 +255,8 @@ router.get('/_hashes', async (req, res, next) => {
   const site = await reqSite(req)
   res.send({
     publicInfo: site ? getPublicSiteInfoHash(site) : defaultPublicSiteInfoHash,
-    themeCss: site ? getThemeCssHash(site) : defaultThemeCssHash
+    themeCss: site ? getThemeCssHash(site) : defaultThemeCssHash,
+    preloadLinks: site?.theme.preloadLinks ?? config.theme.preloadLinks ?? []
   })
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
       },
       "devDependencies": {
         "@commitlint/config-conventional": "^19.8.1",
-        "@data-fair/lib-express": "^1.19.0",
-        "@data-fair/lib-node": "^2.12.1",
+        "@data-fair/lib-express": "^1.23.0",
+        "@data-fair/lib-node": "^2.13.1",
         "@playwright/test": "^1.59.1",
         "@reporters/bail": "^1.3.1",
         "@types/accept-language-parser": "^1.5.8",
@@ -65,7 +65,7 @@
       "license": "MIT",
       "dependencies": {
         "@authenio/samlify-node-xmllint": "^2.0.0",
-        "@data-fair/lib-express": "^1.19.0",
+        "@data-fair/lib-express": "^1.23.0",
         "@data-fair/lib-node": "^2.12.1",
         "@data-fair/lib-utils": "^1.10.1",
         "@sd/shared": "*",
@@ -675,9 +675,9 @@
       "license": "MIT"
     },
     "node_modules/@data-fair/lib-common-types": {
-      "version": "1.20.6",
-      "resolved": "https://registry.npmjs.org/@data-fair/lib-common-types/-/lib-common-types-1.20.6.tgz",
-      "integrity": "sha512-9FJFyK0Q0p+1xxuiEjDJvfAOzgZIDWt6hJAe+mjYqcR1fa9jmB/eg4JdzOqyo4YCpsisQ634CYKhkJXnpT7izA==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@data-fair/lib-common-types/-/lib-common-types-1.21.0.tgz",
+      "integrity": "sha512-LBppiR7ncYLIpDxZLmXHIDvGmUHjqwc3F+qXuVSS4vDpgvCL8RWhT6396DSXMpgbY0I3aKZ8T6LGpPxz8qB4/Q==",
       "license": "MIT",
       "dependencies": {
         "@data-fair/lib-utils": "^1.6.1",
@@ -694,9 +694,9 @@
       }
     },
     "node_modules/@data-fair/lib-express": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@data-fair/lib-express/-/lib-express-1.22.2.tgz",
-      "integrity": "sha512-lGosAIOXrLyqO3InkOe4PsmH7XDJS5UKAeK3dCgN+tdQVzYSJjgyvd9L/jzJTmmZ5KDPVXS3kxFDyNNnUsMAmg==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@data-fair/lib-express/-/lib-express-1.23.1.tgz",
+      "integrity": "sha512-sYVyaRvtpVkS1vPLAm8VOlkSnizcdRFXGYKQuWl/6/mu0uvPPIA2YliU+wajfyZaWN9q1fIbJ9p9My5xvBDVUw==",
       "license": "MIT",
       "dependencies": {
         "@data-fair/lib-common-types": "^1.7.1",
@@ -707,7 +707,7 @@
         "serialize-javascript": "^7.0.0"
       },
       "peerDependencies": {
-        "@data-fair/lib-node": "^2.9.0",
+        "@data-fair/lib-node": "^2.13.1",
         "express": "5",
         "ws": "8"
       },
@@ -718,9 +718,9 @@
       }
     },
     "node_modules/@data-fair/lib-node": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@data-fair/lib-node/-/lib-node-2.12.1.tgz",
-      "integrity": "sha512-qNQwLV1XbzrRs/UlhHWWJRArenIy7qdg9JKuWK/NPnlLAJAzTvWkiOM/Q2UVnFo2CquJ4+7uUMymhEt7+nBw+Q==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@data-fair/lib-node/-/lib-node-2.13.2.tgz",
+      "integrity": "sha512-EepEQ3lIAf4sD1JwyGNX+Seb2abY/DN/ouGs6Ek/PXbrI8J/uo4YprOaclJTrvhcpGQkhHEvurpUzNGijhjZ+g==",
       "license": "MIT",
       "dependencies": {
         "@data-fair/lib-common-types": "^1.8.4",
@@ -729,6 +729,9 @@
         "agentkeepalive": "^4.5.0",
         "axios": "^1.7.7",
         "cacheable-lookup": "^7.0.0",
+        "cookie": "^0.7.2",
+        "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.1.0",
         "semver": "^7.6.3"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "homepage": "https://github.com/koumoul-dev/simple-directory#readme",
   "devDependencies": {
     "@commitlint/config-conventional": "^19.8.1",
-    "@data-fair/lib-express": "^1.19.0",
-    "@data-fair/lib-node": "^2.12.1",
+    "@data-fair/lib-express": "^1.23.0",
+    "@data-fair/lib-node": "^2.13.1",
     "@playwright/test": "^1.59.1",
     "@reporters/bail": "^1.3.1",
     "@types/accept-language-parser": "^1.5.8",

--- a/tests/features/pseudo-session.api.spec.ts
+++ b/tests/features/pseudo-session.api.spec.ts
@@ -110,6 +110,6 @@ test.describe('Pseudo session', () => {
     } catch (err: any) {
       caughtError = err
     }
-    assert.equal(caughtError.status, 401)
+    assert.equal(caughtError.status, 403)
   })
 })


### PR DESCRIPTION
Expose a `preloadLinks` list in `GET /sites/_hashes` so SPA consumers (`@data-fair/lib` `serve-spa`, the Nuxt portal) can emit `<link rel="preload">` and fetch a site's resources in parallel with the theme stylesheet.

**What changed:**
- `GET /sites/_hashes` returns `preloadLinks: [{ href, as?, type?, crossorigin? }]` (renamed from `fonts`), taken straight from the theme's `preloadLinks` field (defined in @data-fair/lib, populated by the portals manager for custom fonts).
- simple-directory is a **plain relay**: it forwards the theme's `preloadLinks` verbatim (or the default theme's when the site sets none). No dedup, no per-resource logic, no `{SITE_PATH}` templating — the producer (portals + default theme) builds the complete, final list.
- `config.ts` drops the default Nunito link when the operator configures a custom body font via `THEME_*`.

**Why:** load a site's fonts (and tomorrow other resources like a logo) in parallel with the theme instead of waiting for `_theme.css`. Per review, SD does nothing but move the link list to where consumers need it.

**Regression risks:**
- `_hashes` field renamed `fonts` → `preloadLinks`; lib (data-fair/lib#40, `serve-spa`) and portals (data-fair/portals#73) read the new key — deploy together.
- Requires the matching `@data-fair/lib-common-types` release (theme `preloadLinks` with explicit `href` / `as` / `type` / `crossorigin`).
- Dropped the previous per-slot fallback, dedup and `{SITE_PATH}` resolution — intentional; that logic now lives with the producer, and the default href is absolute now that sitePath is being deprecated.
- Bumps `@data-fair/lib-express` `^1.19→^1.23` (and `lib-node` `^2.12.1→^2.13.1`) — that's how the `preloadLinks` theme field reaches this service. The bump also changes pseudo-session behavior: non-GET requests on a pseudo session now return **403** instead of **401** (`lib-express` session.js). `pseudo-session.api.spec.ts`'s keepalive assertion was updated to match; any external consumer keying on `401` for that case will now see `403`.
