### PR TITLE
fix: search partners by name/email and show a message when empty

### DIFF
--- a/api/i18n/de.js
+++ b/api/i18n/de.js
@@ -33,6 +33,7 @@ export default {
     orgStorageMembers: 'Mitglieder im sekundären Speicher',
     role: 'Rolle',
     search: 'Suche',
+    noResult: 'Kein Ergebnis',
     confirmOk: 'Ok',
     confirmCancel: 'Abbrechen',
     confirmTitle: 'Möchten Sie diese Operation bestätigen?',

--- a/api/i18n/en.js
+++ b/api/i18n/en.js
@@ -33,6 +33,7 @@ export default {
     orgStorageMembers: 'Members in secondary storage',
     role: 'Role',
     search: 'Search',
+    noResult: 'No result',
     confirmOk: 'Ok',
     confirmCancel: 'Cancel',
     confirmTitle: 'Do you want to confirm this operation ?',

--- a/api/i18n/es.js
+++ b/api/i18n/es.js
@@ -33,6 +33,7 @@ export default {
     orgStorageMembers: 'Miembros en almacenamiento secundario',
     role: 'Papel',
     search: 'Buscar',
+    noResult: 'Sin resultados',
     confirmOk: 'Ok',
     confirmCancel: 'Anular',
     confirmTitle: '¿Desea confirmar esta operación?',

--- a/api/i18n/fr.js
+++ b/api/i18n/fr.js
@@ -33,6 +33,7 @@ export default {
     orgStorageMembers: 'Membres dans le stockage secondaire',
     role: 'Rôle',
     search: 'Rechercher',
+    noResult: 'Aucun résultat',
     confirmOk: 'Ok',
     confirmCancel: 'Annuler',
     confirmTitle: 'Souhaitez-vous confirmer cette opération ?',

--- a/api/i18n/it.js
+++ b/api/i18n/it.js
@@ -33,6 +33,7 @@ export default {
     orgStorageMembers: 'Membri nello storage secondario',
     role: 'Ruolo',
     search: 'Ricerca',
+    noResult: 'Nessun risultato',
     confirmOk: 'Ok',
     confirmCancel: 'Annulla',
     confirmTitle: 'Vuoi confermare questa operazione?',

--- a/api/i18n/pt.js
+++ b/api/i18n/pt.js
@@ -33,6 +33,7 @@ export default {
     orgStorageMembers: 'Membros no armazenamento secundário',
     role: 'Papel',
     search: 'Pesquisa',
+    noResult: 'Nenhum resultado',
     confirmOk: 'Ok',
     confirmCancel: 'Cancelar',
     confirmTitle: 'Deseja confirmar esta operação?',

--- a/ui/src/components/organization-partners.vue
+++ b/ui/src/components/organization-partners.vue
@@ -51,8 +51,17 @@
       </v-col>
     </v-row>
 
+    <v-alert
+      v-if="orga.partners?.length && !filteredPartners.length"
+      type="info"
+      variant="tonal"
+      class="mt-1"
+    >
+      {{ $t('common.noResult') }}
+    </v-alert>
+
     <v-list
-      v-if="orga.partners?.length"
+      v-if="filteredPartners.length"
       lines="two"
       class="py-0 mt-1 border-sm"
     >
@@ -145,7 +154,8 @@ const adminMode = computed(() => !!session.user.value?.adminMode)
 const writablePartners = computed(() => (isAdminOrga && (!$uiConfig.readonly || $uiConfig.orgStorageOverwrite?.includes('partners'))) || adminMode.value)
 const filteredPartners = computed(() => {
   if (!validQ.value) return orga.partners ?? []
-  else return (orga.partners ?? []).filter(d => (d.id && d.id.includes(validQ.value)) || (d.id && d.id.includes(validQ.value)))
+  const lowerQ = validQ.value.toLowerCase()
+  return (orga.partners ?? []).filter(d => d.name?.toLowerCase().includes(lowerQ) || d.contactEmail?.toLowerCase().includes(lowerQ))
 })
 const currentPage = computed(() => filteredPartners.value.slice((page.value - 1) * pageSize, page.value * pageSize))
 


### PR DESCRIPTION
The partners list search filtered on the opaque partner org id (and the OR clause was duplicated), so it never matched the name/email the user types and always returned an empty list. Filter on name and contactEmail case-insensitively, and render a "no result" message instead of an empty list when the search yields nothing.