### PR TITLE
fix(sites): default new sites to onlyOtherSite when a primary exists

### DIFF
--- a/api/src/sites/router.ts
+++ b/api/src/sites/router.ts
@@ -3,7 +3,7 @@ import { Router, type Request } from 'express'
 import config from '#config'
 import { reqUser, reqUserAuthenticated, reqSiteUrl, httpError, reqSessionAuthenticated, type AccountKeys } from '@data-fair/lib-express'
 import { nanoid } from 'nanoid'
-import { findAllSites, findOwnerSites, patchSite, deleteSite, getSite, toggleMainSite } from './service.ts'
+import { findAllSites, findOwnerSites, patchSite, deleteSite, getSite, toggleMainSite, findMainSite } from './service.ts'
 import { getThemeCss, getThemeCssHash, defaultThemeCssHash, defaultThemeCss } from '../utils/theme.ts'
 import { isOIDCProvider, reqSite } from '#services'
 import { reqI18n } from '#i18n'
@@ -130,6 +130,13 @@ router.post('', async (req, res, next) => {
   if (postSite.contact) {
     patch.mails = existingSite?.mails ?? {}
     patch.mails.contact = postSite.contact
+  }
+  if (!existingSite && (patch.authMode === undefined || patch.authMode === 'onlyBackOffice')) {
+    const mainSite = await findMainSite(postSite.owner)
+    if (mainSite) {
+      patch.authMode = 'onlyOtherSite'
+      patch.authOnlyOtherSite = mainSite.host
+    }
   }
   patch.updatedAt = new Date().toISOString()
   const patchedSite = await patchSite(patch, true)

--- a/api/src/sites/service.ts
+++ b/api/src/sites/service.ts
@@ -128,6 +128,14 @@ export async function getSite (siteId: string) {
   return mongo.sites.findOne({ _id: siteId })
 }
 
+export async function findMainSite (owner: AccountKeys) {
+  return mongo.sites.findOne({
+    'owner.type': owner.type,
+    'owner.id': owner.id,
+    isAccountMain: true
+  })
+}
+
 export async function patchSite (patch: Partial<Site> & Pick<Site, '_id'>, createIfMissing = false) {
   return (await mongo.sites.findOneAndUpdate({ _id: patch._id }, { $set: patch }, { upsert: createIfMissing, returnDocument: 'after' })) as Site
 }

--- a/tests/features/sites.api.spec.ts
+++ b/tests/features/sites.api.spec.ts
@@ -73,4 +73,37 @@ test.describe('sites api', () => {
     // using site_redirect is no longer possible
     await assert.rejects(ax.post<string>('/api/auth/site_redirect', { redirect: siteDirectoryUrl }), { status: 400 })
   })
+
+  test('should default a new site to onlyOtherSite when the owner already has a primary site', async () => {
+    const config = await getServerConfig()
+
+    const { ax: adminAx } = await createUser('admin@test.com', true)
+    const anonymousAx = await axios()
+    const { ax } = await createUser('test-site-secondary@test.com')
+    const org = (await ax.post('/api/organizations', { name: 'test_sites_secondary' })).data
+    const owner = { type: 'organization', id: org.id, name: org.name }
+
+    const mainHost = '127.0.0.1:' + process.env.NGINX_PORT2
+    const secondaryHost = '127.0.0.1:' + process.env.NGINX_PORT3
+
+    // 1. create the primary site and toggle it to isAccountMain
+    await anonymousAx.post('/api/sites',
+      { _id: 'test_sites_main', owner, host: mainHost, theme: { primaryColor: '#FF00FF' } },
+      { params: { key: config.secretKeys.sites } })
+    await adminAx.patch('/api/sites/test_sites_main', { isAccountMain: true })
+    await testEnvAx.post('/clear-site-cache')
+
+    // 2. create a second site for the same owner via the webhook (POST /api/sites)
+    //    it must default to onlyOtherSite pointing to the primary site
+    const newSite = (await anonymousAx.post('/api/sites',
+      { _id: 'test_sites_secondary', owner, host: secondaryHost, theme: { primaryColor: '#FF00FF' } },
+      { params: { key: config.secretKeys.sites } })).data
+    assert.equal(newSite.authMode, 'onlyOtherSite')
+    assert.equal(newSite.authOnlyOtherSite, mainHost)
+
+    // 3. same alignment is visible in the public info
+    const secondaryPublic = (await anonymousAx.get(`http://${secondaryHost}/simple-directory/api/sites/_public`)).data
+    assert.equal(secondaryPublic.authMode, 'onlyOtherSite')
+    assert.equal(secondaryPublic.authOnlyOtherSite, mainHost)
+  })
 })


### PR DESCRIPTION
When a new site is created through the `POST /api/sites` webhook and its owner
already has a site flagged `isAccountMain`, the new site now defaults to
`authMode: 'onlyOtherSite'` pointing at the primary site's host, instead of
falling back to `onlyBackOffice`.

**Why:** `toggleMainSite` already rewrites every *existing* sibling site to
`onlyOtherSite` when a site is promoted to primary, but sites created afterwards
were left on `onlyBackOffice` — so a newly added secondary portal delegated login
to the back-office rather than to the account's primary site.

**Heads-up:** the new branch also overrides an explicitly-passed
`authMode: 'onlyBackOffice'`, not just an absent one. This is intentional
(`onlyBackOffice` on a secondary site is a meaningless configuration) but it does
mean the portals manager can no longer pin a secondary site to that mode.
Existing deployments will see the next site created for an org with a primary
site come up in `onlyOtherSite` mode.
